### PR TITLE
feat(ux): responsive layout for diagram on tablet/mobile (#6)

### DIFF
--- a/oia-site/src/renderer/render-diagram.ts
+++ b/oia-site/src/renderer/render-diagram.ts
@@ -7,6 +7,12 @@ export function renderOIA(model: OIAModel): HTMLElement {
   const wrapper = document.createElement('div')
   wrapper.className = 'diagram-wrapper'
 
+  // Mobile notice (hidden on desktop via CSS)
+  const notice = document.createElement('div')
+  notice.className = 'mobile-notice'
+  notice.textContent = 'Best viewed on desktop — pinch to zoom or rotate to landscape'
+  wrapper.appendChild(notice)
+
   // Header
   const header = document.createElement('div')
   header.className = 'header'

--- a/oia-site/src/router.ts
+++ b/oia-site/src/router.ts
@@ -18,7 +18,12 @@ import {
 let model: OIAModel
 let appContainer: HTMLElement
 let navElement: HTMLElement | null = null
-let zoomValue = ZOOM_DEFAULT
+const DIAGRAM_NATIVE_WIDTH = 1440
+function getInitialZoom(): number {
+  return Math.max(ZOOM_MIN, Math.min(ZOOM_DEFAULT, window.innerWidth / DIAGRAM_NATIVE_WIDTH))
+}
+
+let zoomValue = getInitialZoom()
 
 function setZoom(val: number) {
   zoomValue = val

--- a/oia-site/src/styles/layout.css
+++ b/oia-site/src/styles/layout.css
@@ -612,6 +612,38 @@ body::after {
   transform-origin: top center;
 }
 
+/* ── MOBILE NOTICE ── */
+.mobile-notice {
+  display: none;
+}
+
+/* ── RESPONSIVE ── */
+@media (max-width: 1440px) {
+  #app {
+    overflow-x: hidden;
+  }
+  .diagram-wrapper {
+    margin-left: 0;
+    transform-origin: top left;
+  }
+}
+
+@media (max-width: 768px) {
+  .mobile-notice {
+    display: block;
+    font-family: 'Space Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    background: rgba(77, 184, 255, 0.04);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 8px 14px;
+    margin-bottom: 16px;
+    text-align: center;
+  }
+}
+
 /* ── HEADER ── */
 .header {
   text-align: center;

--- a/oia-site/tests/router.spec.ts
+++ b/oia-site/tests/router.spec.ts
@@ -36,6 +36,7 @@ describe('initRouter — overview route (#/)', () => {
   })
 
   test('default zoom is 75% → zoom-full class on diagram-wrapper', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1440, configurable: true })
     const { initRouter } = await import('../src/router')
     initRouter(model, container)
     const wrapper = container.querySelector('.diagram-wrapper') as HTMLElement
@@ -43,6 +44,7 @@ describe('initRouter — overview route (#/)', () => {
   })
 
   test('zoom label shows 75%', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1440, configurable: true })
     const { initRouter } = await import('../src/router')
     initRouter(model, container)
     const label = container.querySelector('.zoom-label')


### PR DESCRIPTION
## Summary

- Initial zoom scales to `viewport / 1440` on screens < 1440px — no horizontal overflow on tablet
- `transform-origin: top left` on small screens so diagram scales from left edge
- `overflow-x: hidden` on `#app` at ≤1440px clips any residual overflow
- Mobile notice (≤768px): "Best viewed on desktop — pinch to zoom or rotate to landscape"
- Zoom slider still works for manual adjustment on all screen sizes

## Test plan

- [ ] 50/50 tests pass (`npm test`)
- [ ] Clean build (`npm run build`)
- [ ] On tablet viewport (≈1024px): diagram fits without horizontal scrollbar
- [ ] On mobile viewport (≈375px): notice visible, diagram scrollable

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)