### PR TITLE
docs(conventions): anchor No-Duplicate Rule centrally (#128)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -108,6 +108,19 @@ Categories: `model` · `renderer` · `prompt` · `architecture` · `infra` · `u
 
 See [ADR-0003](decisions/adr/0003-github-issues-as-task-tracker.md) for rationale.
 
+### No-Duplicate Rule
+
+**Every workflow that creates GitHub Issues must run the duplicate check first — without exception.**
+
+This applies to all prompts, scripts, and AI-assisted workflows:
+
+1. Load open issues: `gh issue list --state open --limit 100`
+2. Check for overlap by **title keywords** and **affected file/component**.
+3. Clear overlap → **do not create** — reference the existing issue instead.
+4. Uncertain → create the issue and add `possibly related to #N` in the body.
+
+This rule is authoritative here. All prompts that create issues must reference it by name (`CONVENTIONS.md §2.4 No-Duplicate Rule`) rather than repeating the procedure inline. See [ADR-0003](decisions/adr/0003-github-issues-as-task-tracker.md) for the original definition and rationale.
+
 ### Issue closing rules
 
 **Close-Verifikation:** When closing an issue, the close comment must verify each AC item explicitly:

--- a/decisions/adr/0003-github-issues-as-task-tracker.md
+++ b/decisions/adr/0003-github-issues-as-task-tracker.md
@@ -55,6 +55,8 @@ Before creating any issue, the existing open issues must be checked for duplicat
 
 This rule applies to all automated issue creation (prompts, scripts, AI assistants) and manual creation alike.
 
+**Operational rule:** The authoritative, named statement of this rule is in `CONVENTIONS.md §2.4 No-Duplicate Rule`. Prompts reference it there — not inline.
+
 ## Alternatives
 
 | Option | Reason rejected |

--- a/prompts/development/create-issue.md
+++ b/prompts/development/create-issue.md
@@ -36,7 +36,7 @@ If inputs are missing: ask before creating anything.
 
 ## Constraints
 
-- **No issue without duplicate check** — load open issues first
+- **No issue without duplicate check** — per `CONVENTIONS.md §2.4 No-Duplicate Rule` and ADR-0003; load open issues first
 - **No issue for BIZ content** (OIA model IDs, layer names) without explicit user confirmation
 - **No vague title** — must follow Conventional Commits format
 - **At least 2 labels** — domain + category


### PR DESCRIPTION
## Summary

- ADR-0003 defined the No-Duplicate Rule but it was absent as a named, authoritative rule in `CONVENTIONS.md`
- Each issue-creating prompt (project-review.md, create-issue.md) implemented the check inline without a central reference
- New prompts could omit the check without violating any explicitly named rule

**Changes:**
- `CONVENTIONS.md §2.4`: new named `### No-Duplicate Rule` subsection — authoritative statement; prompts reference it by name instead of repeating the procedure
- `decisions/adr/0003-github-issues-as-task-tracker.md`: cross-reference added pointing to `CONVENTIONS.md §2.4`
- `prompts/development/create-issue.md`: Constraint line updated to cite `CONVENTIONS.md §2.4 No-Duplicate Rule` and ADR-0003

**Note:** `project-review.md` is handled in PR #129 (feature branch already references ADR-0003 by name — will align with CONVENTIONS.md §2.4 once both PRs are merged).

## Merge order

Merge #129 first, then this PR — no hard dependency, but #129's project-review.md already uses the ADR reference that this PR formalizes.

## Test plan

- [ ] `CONVENTIONS.md §2.4` contains a named `### No-Duplicate Rule` subsection
- [ ] ADR-0003 cross-references `CONVENTIONS.md §2.4`
- [ ] `create-issue.md` Constraint references `CONVENTIONS.md §2.4 No-Duplicate Rule`
- [ ] No source files were changed

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)