### PR TITLE
docs(sprints): add English language requirement to sprint-planning.md (#135)

### DIFF
--- a/prompts/development/sprint-planning.md
+++ b/prompts/development/sprint-planning.md
@@ -143,6 +143,8 @@ Create `sprints/YYYY-MM-DD.md` with the sprint goal, DoD, and issue list.
 
 **Duplicate file handling:** If `sprints/YYYY-MM-DD.md` already exists, append a two-digit counter suffix starting at `00`: `YYYY-MM-DD-00.md`, `YYYY-MM-DD-01.md`, etc. Check with `ls sprints/YYYY-MM-DD*.md` before creating.
 
+**Language:** Sprint file content must be in English — per ODR-0004. Goal, DoD, section headers, and notes are all English.
+
 ---
 
 ### ⏸ CHECKPOINT 2 — Handshake


### PR DESCRIPTION
## Summary

- Added explicit English language requirement to `sprint-planning.md` Step C-5 — per ODR-0004
- Sprint files are gitignored (local planning notes); existing files translated locally
- Future sprint files will be created in English by default

## Test plan

- [ ] `sprint-planning.md` Step C-5 contains the ODR-0004 language note
- [ ] CI prompt compliance check passes

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)