### PR TITLE
style(renderer): replace inline styles with CSS classes (#132)

### DIFF
--- a/oia-site/src/renderer/render-layer-blocks.ts
+++ b/oia-site/src/renderer/render-layer-blocks.ts
@@ -17,7 +17,7 @@ export function renderActorsLayer(model: OIAModel, layer: Container): string {
             : ''
         })
         .join('')
-      return `<div class="actor-group ${frame.meta?.variant || ''}" data-id="${frame.id}" style="cursor:pointer">
+      return `<div class="actor-group ${frame.meta?.variant || ''}" data-id="${frame.id}">
       <div class="actor-group-title">${frame.meta?.icon || ''} ${frame.label}${getBadgeIcons(model, frame.badges)}</div>
       <div class="tag-row">${tags}</div>
     </div>`
@@ -47,7 +47,7 @@ export function renderKnowledgeCore(model: OIAModel, layer: Container): string {
           return child ? child.label : ''
         })
         .join('<br>')
-      return `<div class="core-block" data-id="${box.id}" style="cursor:pointer">
+      return `<div class="core-block" data-id="${box.id}">
       <div class="core-block-title">${box.label}</div>
       <div class="core-block-items">${items}</div>
     </div>`
@@ -63,11 +63,9 @@ export function renderPipeline(model: OIAModel, layer: Container): string {
       if (!item) return ''
       const isLast = i === arr.length - 1
       const isOutput = item.properties?.variant === 'output'
-      const style = isOutput
-        ? ' style="border-color:var(--accent2-dim);color:var(--accent2-high)"'
-        : ''
+      const outputClass = isOutput ? ' pipeline-step--output' : ''
       const arrow = !isLast ? '<div class="pipeline-arrow">→</div>' : ''
-      return `<div class="pipeline-step"${style}>${item.icon || ''}<br>${item.label}</div>${arrow}`
+      return `<div class="pipeline-step${outputClass}">${item.icon || ''}<br>${item.label}</div>${arrow}`
     })
     .join('')
   return `<div class="pipeline-row">${steps}</div>`

--- a/oia-site/src/renderer/render-layer.ts
+++ b/oia-site/src/renderer/render-layer.ts
@@ -37,17 +37,16 @@ export function renderLayer(model: OIAModel, layer: Container): HTMLElement {
 
   const wrapper = document.createElement('div')
   wrapper.dataset.id = layer.id
-  wrapper.style.cursor = 'pointer'
 
   if (isCore) {
     wrapper.className = 'layer-core'
     const numId = layer.id.replace('#', '')
     wrapper.innerHTML = `
       <div class="layer-header">
-        <span class="layer-num" style="color:var(--accent2);opacity:0.6">${numId}</span>
+        <span class="layer-num layer-num--core">${numId}</span>
         <span class="layer-title">${layer.label}</span>
         <span class="core-badge">CENTRAL COMPONENT</span>
-        <span class="layer-desc" style="color:var(--accent2-mid)">${layer.description || ''}</span>
+        <span class="layer-desc layer-desc--core">${layer.description || ''}</span>
         ${getBadgeIcons(model, layer.badges)}
       </div>
       ${renderKnowledgeCore(model, layer)}

--- a/oia-site/src/renderer/render-panel.ts
+++ b/oia-site/src/renderer/render-panel.ts
@@ -11,17 +11,16 @@ function resolveChildren(model: OIAModel, ids: string[]): string {
       }
       if (element.type === 'container') {
         const isQualityGates = element.meta?.variant === 'highlight'
-        const style = isQualityGates ? ' style="border-color:var(--accent2-dim);"' : ''
-        const titleStyle = isQualityGates ? ' style="color:var(--accent2)"' : ''
-        const itemStyle = isQualityGates ? ' style="border-color:var(--accent2-subtle)"' : ''
+        const blockClass = isQualityGates ? ' side-block--highlight' : ''
+        const itemClass = isQualityGates ? ' side-item--highlight' : ''
         const items = element.children
           .map((cid) => {
             const child = getItem(model, cid)
-            return child ? `<div class="side-item"${itemStyle}>${child.label}</div>` : ''
+            return child ? `<div class="side-item${itemClass}">${child.label}</div>` : ''
           })
           .join('')
-        return `<div class="side-block" data-id="${element.id}"${style}>
-  <div class="side-block-title"${titleStyle}>${element.label}</div>
+        return `<div class="side-block${blockClass}" data-id="${element.id}">
+  <div class="side-block-title">${element.label}</div>
   ${items}
 </div>`
       }

--- a/oia-site/src/styles/components.css
+++ b/oia-site/src/styles/components.css
@@ -54,6 +54,12 @@
   margin-bottom: 2px;
   line-height: 1.3;
 }
+.side-block--highlight {
+  border-color: var(--accent2-dim);
+}
+.side-item--highlight {
+  border-left-color: var(--accent2-subtle);
+}
 
 /* ── LAYER CARD ── */
 .layer {
@@ -61,6 +67,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 12px 16px;
+  cursor: pointer;
   transition: border-color 0.2s;
 }
 .layer:hover {
@@ -78,6 +85,10 @@
   color: var(--text-muted);
   min-width: 28px;
 }
+.layer-num--core {
+  color: var(--accent2);
+  opacity: 0.6;
+}
 .layer-title {
   font-family: 'Space Mono', monospace;
   font-size: 10px;
@@ -91,6 +102,9 @@
   color: var(--text-muted);
   margin-left: auto;
   font-style: italic;
+}
+.layer-desc--core {
+  color: var(--accent2-mid);
 }
 
 /* ── TAG CHIPS ── */
@@ -145,6 +159,7 @@
   border: 1.5px solid rgba(44, 242, 194, 0.4);
   border-radius: 10px;
   padding: 16px;
+  cursor: pointer;
   box-shadow: var(--core-glow);
   position: relative;
   overflow: hidden;
@@ -189,6 +204,7 @@
   border-radius: var(--radius-chip);
   padding: 7px 8px;
   text-align: center;
+  cursor: pointer;
   transition: border-color 0.2s;
 }
 .core-block:hover {
@@ -224,6 +240,10 @@
   font-size: 11px;
   color: var(--text-dim);
 }
+.pipeline-step--output {
+  border-color: var(--accent2-dim);
+  color: var(--accent2-high);
+}
 .pipeline-arrow {
   flex: 0 0 24px;
   text-align: center;
@@ -243,6 +263,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   padding: 10px 12px;
+  cursor: pointer;
   transition: border-color 0.2s;
 }
 .actor-group:hover {


### PR DESCRIPTION
## Summary

- Removes all inline `style=` attributes from renderer template strings
- Adds `cursor: pointer` directly to `.layer`, `.layer-core`, `.actor-group`, `.core-block` CSS classes
- Introduces named modifier classes: `.layer-num--core`, `.layer-desc--core`, `.pipeline-step--output`, `.side-block--highlight`, `.side-item--highlight`
- Drops redundant `titleStyle` override in `render-panel.ts` (`.side-block-title` already defaults to `var(--accent2)`)

## Test plan

- [ ] Build passes (`npm run build` — verified clean)
- [ ] Visual check: Knowledge Core layer header (accent2 num + desc), pipeline output step, side panel highlight blocks render identically to before

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)