### PR TITLE
chore(process): sprint retro improvements — 2026-03-14 (#126)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,8 @@ See CONVENTIONS.md §Git Workflow and [ADR-0014](decisions/adr/0014-feature-bran
 
 **Branch per issue:** Every issue is implemented on a dedicated branch (`feature/#N-description`, `fix/#N-description`, etc.).
 
+**Branch check before commit:** Before staging and committing, verify the current branch with `git branch --show-current` — especially when switching between feature branches mid-session. Never commit to the wrong branch.
+
 **Agent push autonomy:** Push to a feature branch at any time — no chat confirmation required. Notify the human in chat when opening a PR.
 
 **Never merge to main:** Open the PR, summarize the changes in chat, and wait for human approval. The human merges.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -230,6 +230,8 @@ describe('<FunctionName>', () => {
 })
 ```
 
+**Browser-environment defaults:** When implementing logic that depends on browser properties (e.g. `window.innerWidth`, `window.innerHeight`), note the JSDOM default before writing tests (`innerWidth` defaults to `1024`, `innerHeight` to `768`) and confirm that test setup matches the implementation assumption.
+
 ---
 
 ## 2.10 Prompts
@@ -253,6 +255,14 @@ When introducing a new concept into the project (a new documentation format, a n
 **Rule:** Never start integration work before the concept design is complete. Starting integration on an unstable concept creates rework across all integration points.
 
 **Mandatory entry point:** `prompts/development/integrate-concept.md` — use it for every new concept introduction, without exception.
+
+---
+
+## 2.13 New Public Artifacts
+
+Before creating new top-level directories, new root-level files, or any other repository artifact that becomes public content, verify that an ADR or ODR covers the decision. If none exists: raise the question with the human maintainer first and block implementation until confirmed.
+
+**Rule:** Do not create public repository artifacts without a decision record authorizing them. If uncertain whether a record exists, check `decisions/README.md` first.
 
 ---
 


### PR DESCRIPTION
## Summary

Anchors three process improvements from the 2026-03-14-tech sprint retro:

- **CLAUDE.md** — branch-check rule: verify current branch with `git branch --show-current` before staging/committing, especially mid-session when switching between feature branches
- **CONVENTIONS.md §2.9** — JSDOM defaults note: `innerWidth` = 1024, `innerHeight` = 768; confirm test setup matches implementation assumption before writing browser-dependent logic
- **CONVENTIONS.md §2.13** — new-artifact decision gate: before creating new top-level dirs or root files, verify an ADR/ODR covers the decision; block if none exists

## Test plan

- [ ] No code changes — documentation-only
- [ ] Verify the three new rules appear at correct locations in both files

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)