### PR TITLE
test(renderer): add unit tests for getItem, renderLayer, and routing (#131)

### DIFF
--- a/oia-site/src/renderer/render-layer.spec.ts
+++ b/oia-site/src/renderer/render-layer.spec.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, test, expect } from 'vitest'
+import type { OIAModel, Container } from '../data/types'
+import { renderLayer } from './render-layer'
+
+const mockModel: OIAModel = {
+  meta: { version: '0.1.0', title: 'OIA', subtitle: '', created: '2024-01-01' },
+  elements: [],
+  connections: [],
+  badges: [],
+  views: [],
+  legend: { show: false, position: 'bottom' },
+}
+
+const standardLayer: Container = {
+  id: '#L1',
+  type: 'container',
+  containerType: 'layer',
+  label: 'Data Layer',
+  description: 'Data sources',
+  children: [],
+}
+
+const coreLayer: Container = {
+  id: '#L3',
+  type: 'container',
+  containerType: 'layer',
+  label: 'Knowledge Core',
+  description: 'Central component',
+  children: [],
+  meta: { highlighted: true },
+}
+
+describe('renderLayer', () => {
+  test('returns element with class "layer" for standard layer', () => {
+    const el = renderLayer(mockModel, standardLayer)
+    expect(el.className).toBe('layer')
+  })
+
+  test('returns element with class "layer-core" for highlighted layer', () => {
+    const el = renderLayer(mockModel, coreLayer)
+    expect(el.className).toBe('layer-core')
+  })
+
+  test('sets data-id attribute from layer id', () => {
+    const el = renderLayer(mockModel, standardLayer)
+    expect(el.dataset.id).toBe('#L1')
+  })
+
+  test('renders badge icons on tagged layers', () => {
+    const el = renderLayer(mockModel, standardLayer)
+    expect(el.querySelector('.layer-header')).not.toBeNull()
+  })
+})

--- a/oia-site/src/renderer/utils.spec.ts
+++ b/oia-site/src/renderer/utils.spec.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from 'vitest'
+import type { OIAModel } from '../data/types'
+import { getItem } from './utils'
+
+const mockModel: OIAModel = {
+  meta: { version: '0.1.0', title: 'OIA', subtitle: '', created: '2024-01-01' },
+  elements: [
+    { id: '#L1', type: 'container', containerType: 'layer', label: 'Data Layer', children: [] },
+    { id: '#item1', type: 'item', itemType: 'datasource', label: 'Item One' },
+  ],
+  connections: [],
+  badges: [],
+  views: [],
+  legend: { show: false, position: 'bottom' },
+}
+
+describe('getItem', () => {
+  test('returns element for known container id', () => {
+    const result = getItem(mockModel, '#L1')
+    expect(result).toBeDefined()
+    expect(result?.label).toBe('Data Layer')
+  })
+
+  test('returns element for known item id', () => {
+    const result = getItem(mockModel, '#item1')
+    expect(result?.label).toBe('Item One')
+  })
+
+  test('returns undefined for unknown id', () => {
+    const result = getItem(mockModel, '#unknown')
+    expect(result).toBeUndefined()
+  })
+})

--- a/oia-site/src/router.spec.ts
+++ b/oia-site/src/router.spec.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, test, expect } from 'vitest'
+import type { OIAModel } from './data/types'
+import { initRouter } from './router'
+
+const mockModel: OIAModel = {
+  meta: { version: '0.1.0', title: 'OIA', subtitle: '', created: '2024-01-01' },
+  elements: [],
+  connections: [],
+  badges: [],
+  views: [],
+  legend: { show: false, position: 'bottom' },
+}
+
+describe('initRouter', () => {
+  test('renders diagram-wrapper for default hash', () => {
+    window.location.hash = '#/'
+    const container = document.createElement('div')
+    initRouter(mockModel, container)
+    expect(container.querySelector('.diagram-wrapper')).not.toBeNull()
+  })
+
+  test('renders page-view for #/motivation hash', () => {
+    window.location.hash = '#/motivation'
+    const container = document.createElement('div')
+    initRouter(mockModel, container)
+    expect(container.querySelector('.page-view')).not.toBeNull()
+  })
+
+  test('renders page-view for #/contribute hash', () => {
+    window.location.hash = '#/contribute'
+    const container = document.createElement('div')
+    initRouter(mockModel, container)
+    expect(container.querySelector('.page-view')).not.toBeNull()
+  })
+
+  test('renders page-view for #/about hash', () => {
+    window.location.hash = '#/about'
+    const container = document.createElement('div')
+    initRouter(mockModel, container)
+    expect(container.querySelector('.page-view')).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds 3 spec files colocated in `src/` to give the test gate real signal (previously all tests were only in `tests/`, none in `src/`)
- `utils.spec.ts` — `getItem()`: returns correct element for known id, returns undefined for unknown id
- `render-layer.spec.ts` — `renderLayer()`: correct class name for standard vs. highlighted (core) layer, correct `data-id` attribute
- `router.spec.ts` — `initRouter()`: renders `.diagram-wrapper` for default hash, renders `.page-view` for known page hashes (`#/motivation`, `#/contribute`, `#/about`)

## Test plan

- [ ] `npm test` reports 61 tests run, all passing (50 existing + 11 new)
- [ ] CI `pr-check.yml` passes

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)