### PR TITLE
docs(decisions): accept ADR-0007/0010/0012–0016 and ODR-0000–0004 (#150)

### DIFF
--- a/decisions/README.md
+++ b/decisions/README.md
@@ -25,16 +25,16 @@ ADR methodology: Ralf D. Müller / Johannes Dienst (fiveandahalfstars.ninja).
 | [ADR-0004](./adr/0004-adr-format-mueller-dienst.md) | ADR Format: Müller/Dienst Methodology | Accepted | DEV | 2026-03-11 |
 | [ADR-0005](./adr/0005-conventional-commits-with-content-type.md) | Conventional Commits with Custom Content Type | Accepted | DEV | 2026-03-11 |
 | [ADR-0006](./adr/0006-prompt-helper-enforcement.md) | Prompt-Helper Enforcement via CLAUDE.md | Accepted | DEV | 2026-03-11 |
-| [ADR-0007](./adr/0007-versioning-scheme.md) | Versioning Scheme — Semantic Versioning for OIA | Proposed | BOTH | 2026-03-13 |
+| [ADR-0007](./adr/0007-versioning-scheme.md) | Versioning Scheme — Semantic Versioning for OIA | Accepted | BOTH | 2026-03-13 |
 | [ADR-0008](./adr/0008-release-strategy.md) | Release Strategy — GitHub Releases with Manual Trigger | Proposed | DEV | 2026-03-13 |
 | [ADR-0009](./adr/0009-repo-as-source-of-truth-for-contributor-documentation.md) | Repo as Source of Truth — Website as Entry Point | Accepted | DEV | 2026-03-12 |
-| [ADR-0010](./adr/0010-semantic-anchors-as-vocabulary-layer.md) | Semantic Anchors as Shared Vocabulary Layer | Proposed | DEV | 2026-03-12 |
+| [ADR-0010](./adr/0010-semantic-anchors-as-vocabulary-layer.md) | Semantic Anchors as Shared Vocabulary Layer | Accepted | DEV | 2026-03-12 |
 | ~~[ADR-0011](./_obsolete/0011-english-as-project-language.md)~~ | ~~English as the Sole Project Language~~ | Superseded by ODR-0004 | DEV | 2026-03-13 |
-| [ADR-0012](./adr/0012-introduce-odr-governance-layer.md) | Introduce ODR as Governance Documentation Layer | Proposed | BOTH | 2026-03-14 |
-| [ADR-0013](./adr/0013-issue-reference-in-commit-subject.md) | Issue Reference in Commit Subject Line | Proposed | DEV | 2026-03-28 |
-| [ADR-0014](./adr/0014-feature-branch-release-branch-workflow.md) | Feature-Branch and Release-Branch Development Workflow | Proposed | DEV | 2026-03-28 |
-| [ADR-0015](./adr/0015-sprint-based-development-workflow.md) | Sprint-Based Development Workflow | Proposed | DEV | 2026-03-28 |
-| [ADR-0016](./adr/0016-agile-semantic-anchors.md) | Agile Process Semantic Anchors | Proposed | DEV | 2026-03-28 |
+| [ADR-0012](./adr/0012-introduce-odr-governance-layer.md) | Introduce ODR as Governance Documentation Layer | Accepted | BOTH | 2026-03-14 |
+| [ADR-0013](./adr/0013-issue-reference-in-commit-subject.md) | Issue Reference in Commit Subject Line | Accepted | DEV | 2026-03-28 |
+| [ADR-0014](./adr/0014-feature-branch-release-branch-workflow.md) | Feature-Branch and Release-Branch Development Workflow | Accepted | DEV | 2026-03-28 |
+| [ADR-0015](./adr/0015-sprint-based-development-workflow.md) | Sprint-Based Development Workflow | Accepted | DEV | 2026-03-28 |
+| [ADR-0016](./adr/0016-agile-semantic-anchors.md) | Agile Process Semantic Anchors | Accepted | DEV | 2026-03-28 |
 
 ---
 
@@ -44,11 +44,11 @@ ODRs document organizational decisions at the Org layer of the governance hierar
 
 | ODR | Title | Status | Date |
 |---|---|---|---|
-| [ODR-0000](./odr/0000-commit-to-transparent-governance-documentation.md) | Commit to Transparent Governance Documentation | Proposed | 2026-03-14 |
-| [ODR-0001](./odr/0001-oia-ecosystem-type.md) | OIA Ecosystem Type — Community-Driven with Benevolent Dictator | Proposed | 2026-03-14 |
-| [ODR-0002](./odr/0002-adopt-agile-principles.md) | Adopt Agile Software Development Principles | Proposed | 2026-03-14 |
-| [ODR-0003](./odr/0003-adopt-adrs-as-arch-layer-documentation-practice.md) | Adopt ADRs as Arch-Layer Documentation Practice | Proposed | 2026-03-14 |
-| [ODR-0004](./odr/0004-english-as-project-language.md) | English as the Sole Project Language | Proposed | 2026-03-14 |
+| [ODR-0000](./odr/0000-commit-to-transparent-governance-documentation.md) | Commit to Transparent Governance Documentation | Accepted | 2026-03-14 |
+| [ODR-0001](./odr/0001-oia-ecosystem-type.md) | OIA Ecosystem Type — Community-Driven with Benevolent Dictator | Accepted | 2026-03-14 |
+| [ODR-0002](./odr/0002-adopt-agile-principles.md) | Adopt Agile Software Development Principles | Accepted | 2026-03-14 |
+| [ODR-0003](./odr/0003-adopt-adrs-as-arch-layer-documentation-practice.md) | Adopt ADRs as Arch-Layer Documentation Practice | Accepted | 2026-03-14 |
+| [ODR-0004](./odr/0004-english-as-project-language.md) | English as the Sole Project Language | Accepted | 2026-03-14 |
 
 ## ADR Acceptance Rule
 

--- a/decisions/adr/0007-versioning-scheme.md
+++ b/decisions/adr/0007-versioning-scheme.md
@@ -1,7 +1,7 @@
 # ADR-0007: Versioning Scheme — Semantic Versioning for OIA
 
 **Decision:** OIA uses Semantic Versioning (SemVer, semver.org) with the scheme `MAJOR.MINOR.PATCH` across all versioned artifacts: the OIA model + site (coupled, one version), and concept files in `context/` (each versioned independently).
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-13
 **Type:** BOTH
 **Governed by:** —

--- a/decisions/adr/0010-semantic-anchors-as-vocabulary-layer.md
+++ b/decisions/adr/0010-semantic-anchors-as-vocabulary-layer.md
@@ -1,7 +1,7 @@
 # ADR-0010: Semantic Anchors as Shared Vocabulary Layer
 
 **Decision:** The OIA project adopts Semantic Anchors (https://llm-coding.github.io/Semantic-Anchors/) as a shared vocabulary layer for AI-assisted development. The active anchor set is maintained in `context/semantic-anchors.md` and referenced by `CLAUDE.md`. Anchors are invoked in prompts and CLAUDE.md to activate established knowledge domains in the AI assistant without re-explaining them from scratch.
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-12
 **Type:** DEV
 **Governed by:** —

--- a/decisions/adr/0012-introduce-odr-governance-layer.md
+++ b/decisions/adr/0012-introduce-odr-governance-layer.md
@@ -1,7 +1,7 @@
 # ADR-0012: Introduce ODR as Governance Documentation Layer
 
 **Decision:** The project introduces Organizational Decision Records (ODRs) as a distinct documentation layer for organizational decisions, sitting above the existing ADR layer in the governance hierarchy Gov → Org → Arch.
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-14
 **Type:** BOTH
 **Governed by:** [ODR-0000](../odr/0000-commit-to-transparent-governance-documentation.md)

--- a/decisions/adr/0013-issue-reference-in-commit-subject.md
+++ b/decisions/adr/0013-issue-reference-in-commit-subject.md
@@ -1,7 +1,7 @@
 # ADR-0013: Issue Reference in Commit Subject Line
 
 **Decision:** Every commit subject line ends with `(#N)` — the GitHub Issue number in parentheses. The footer `Closes #N` / `Refs #N` is retained alongside it.
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-28
 **Type:** DEV
 **Governed by:** [ODR-0002](../odr/0002-adopt-agile-principles.md)

--- a/decisions/adr/0014-feature-branch-release-branch-workflow.md
+++ b/decisions/adr/0014-feature-branch-release-branch-workflow.md
@@ -1,7 +1,7 @@
 # ADR-0014: Feature-Branch and Release-Branch Development Workflow
 
 **Decision:** OIA uses a feature-branch model: every issue is implemented on a dedicated branch, merged to `main` via a pull request with human approval. Releases are prepared on a `release/vX.Y.Z` branch. There is no `develop` branch.
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-28
 **Type:** DEV
 **Governed by:** [ODR-0002](../odr/0002-adopt-agile-principles.md)

--- a/decisions/adr/0015-sprint-based-development-workflow.md
+++ b/decisions/adr/0015-sprint-based-development-workflow.md
@@ -1,7 +1,7 @@
 # ADR-0015: Sprint-Based Development Workflow
 
 **Decision:** OIA uses a sprint-based development workflow: work is organized in timeboxed iterations (sprints) with a defined goal, a set of issues, and a fixed process cycle of Refinement → Planning → Implementation → Review → Retrospective.
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-28
 **Type:** DEV
 **Governed by:** [ODR-0002](../odr/0002-adopt-agile-principles.md)

--- a/decisions/adr/0016-agile-semantic-anchors.md
+++ b/decisions/adr/0016-agile-semantic-anchors.md
@@ -1,7 +1,7 @@
 # ADR-0016: Agile Process Semantic Anchors
 
 **Decision:** Four agile methodology anchors are added to the OIA active anchor set: Five Whys (Ohno), MoSCoW (Clegg), Testing Pyramid (Fowler/Cohn), and YAGNI (Jeffries/Beck). Each anchor maps to a specific, already-practised OIA process step and must be applied automatically by AI tooling in that context.
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-28
 **Type:** DEV
 **Governed by:** [ADR-0010](./0010-semantic-anchors-as-vocabulary-layer.md)

--- a/decisions/odr/0000-commit-to-transparent-governance-documentation.md
+++ b/decisions/odr/0000-commit-to-transparent-governance-documentation.md
@@ -1,7 +1,7 @@
 # ODR-0000: Commit to Transparent Governance Documentation
 
 **Decision:** OIA commits to making all organizational and architectural decisions explicitly visible, traceable, and machine-readable — through ODRs at the Org layer and ADRs at the Arch layer. Implicit governance is rejected: every binding decision must exist as a versioned artifact.
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-14
 **Level:** Org
 **Binding for:** All

--- a/decisions/odr/0001-oia-ecosystem-type.md
+++ b/decisions/odr/0001-oia-ecosystem-type.md
@@ -1,7 +1,7 @@
 # ODR-0001: OIA Ecosystem Type — Community-Driven with Benevolent Dictator
 
 **Decision:** OIA operates as a **community-driven open project** under a benevolent dictator governance model: contributions are open to all, the project is not controlled by any vendor or commercial interest, and the maintainer holds final decision authority while actively working toward broader governance participation over time.
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-14
 **Level:** Org
 **Binding for:** All

--- a/decisions/odr/0002-adopt-agile-principles.md
+++ b/decisions/odr/0002-adopt-agile-principles.md
@@ -1,7 +1,7 @@
 # ODR-0002: Adopt Agile Software Development Principles
 
 **Decision:** OIA development follows the principles of the Agile Manifesto (2001) as its operating model — accepting the process overhead as the cost of a deliberate risk-minimization strategy, with adaptations for the single-maintainer context.
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-14
 **Level:** Org
 **Binding for:** All

--- a/decisions/odr/0003-adopt-adrs-as-arch-layer-documentation-practice.md
+++ b/decisions/odr/0003-adopt-adrs-as-arch-layer-documentation-practice.md
@@ -1,7 +1,7 @@
 # ODR-0003: Adopt ADRs as Arch-Layer Documentation Practice
 
 **Decision:** OIA uses Architecture Decision Records (ADRs) as the authoritative method for documenting all binding technical and structural decisions at the Arch layer of the governance hierarchy. Every architectural choice with non-obvious alternatives must exist as a versioned ADR.
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-14
 **Level:** Org
 **Binding for:** All

--- a/decisions/odr/0004-english-as-project-language.md
+++ b/decisions/odr/0004-english-as-project-language.md
@@ -1,7 +1,7 @@
 # ODR-0004: English as the Sole Project Language
 
 **Decision:** All OIA project artifacts are written in English. The only exception is LinkedIn articles, which remain in German as an explicit author choice for a German-speaking professional audience. This rule applies to all participants — Users, Agents, and Contributors.
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-14
 **Level:** Org
 **Binding for:** All


### PR DESCRIPTION
## Summary

Sets `**Status:** Proposed` → `**Status:** Accepted` for all decision records that have been actively applied across multiple sprints:

**7 ADRs accepted:**
- ADR-0007 Versioning Scheme (SemVer)
- ADR-0010 Semantic Anchors as Vocabulary Layer
- ADR-0012 Introduce ODR Governance Layer
- ADR-0013 Issue Reference in Commit Subject
- ADR-0014 Feature/Release Branch Workflow
- ADR-0015 Sprint-Based Development Workflow
- ADR-0016 Agile Process Semantic Anchors

**5 ODRs accepted:**
- ODR-0000 Commit to Transparent Governance Documentation
- ODR-0001 OIA Ecosystem Type
- ODR-0002 Adopt Agile Principles
- ODR-0003 Adopt ADRs as Documentation Practice
- ODR-0004 English as Project Language

ADR-0008 (Release Strategy) remains `Proposed`.

**The merge of this PR is the formal acceptance act** per the ADR Acceptance Rule in `decisions/README.md`.

## Test plan

- [ ] All 7 ADRs show `Accepted` in file and in README index
- [ ] All 5 ODRs show `Accepted` in file and in README index
- [ ] ADR-0008 still shows `Proposed`
- [ ] CI passes (ODR/ADR compliance checks in pr-check.yml)

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)