### PR TITLE
style(views): replace inline styles with CSS modifier classes

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -419,4 +419,4 @@ Existing code that pre-dates these conventions is not retroactively fixed. Viola
 
 | File | Violation | Issue |
 |---|---|---|
-| `oia-site/src/renderer/render-layer.ts`, `render-layer-blocks.ts`, `render-panel.ts` | Inline `style=` attributes instead of CSS classes | [#132](https://github.com/ruKurz/oi-architecture/issues/132) |
+| `oia-site/src/views/detail.ts:9` | Dynamic `margin-left:${depth * 16}px` — computed indentation, not replaceable by a static class | [#148](https://github.com/ruKurz/oi-architecture/issues/148) |

--- a/oia-site/src/router.ts
+++ b/oia-site/src/router.ts
@@ -66,7 +66,7 @@ function renderOverview() {
   const controls = document.createElement('div')
   controls.className = 'zoom-controls'
   controls.innerHTML = `
-    <span style="font-size:10px;color:var(--text-muted)">Zoom</span>
+    <span class="zoom-controls__label">Zoom</span>
     <input class="zoom-slider" type="range" min="${ZOOM_MIN * 100}" max="${ZOOM_MAX * 100}" value="${Math.round(zoomValue * 100)}" step="${ZOOM_STEP * 100}">
     <span class="zoom-label">${Math.round(zoomValue * 100)}%</span>
   `

--- a/oia-site/src/styles/layout.css
+++ b/oia-site/src/styles/layout.css
@@ -240,6 +240,58 @@ body::after {
   line-height: 1.9;
 }
 
+/* ── PAGE-VIEW BODY MODIFIERS ── */
+.page-view__body--spaced-xs {
+  margin-bottom: 12px;
+}
+.page-view__body--spaced-sm {
+  margin-bottom: 16px;
+}
+.page-view__body--spaced {
+  margin-bottom: 20px;
+}
+.page-view__body--spaced-lg {
+  margin-bottom: 28px;
+}
+.page-view__body--footnote {
+  margin-top: 20px;
+  font-style: italic;
+  color: var(--text-muted);
+}
+.page-view__body--note {
+  font-style: italic;
+  color: var(--text-muted);
+}
+.page-view__body--muted {
+  color: var(--text-muted);
+}
+.page-view__body--caption {
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+/* ── PAGE-VIEW COMPONENT MODIFIERS ── */
+.page-view__audience--section-gap {
+  margin-bottom: 40px;
+}
+.page-view__manifesto--flow-bottom {
+  margin-bottom: 48px;
+}
+.page-view__manifesto--top-spaced {
+  margin-top: 28px;
+}
+.page-view__card--spaced {
+  margin-bottom: 20px;
+}
+.page-view__join-steps--top-gap {
+  margin-top: 24px;
+}
+.page-view__legal-ref {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 .page-view__link {
   color: var(--accent);
   text-decoration: none;
@@ -734,6 +786,9 @@ body::after {
   text-align: right;
   color: var(--accent);
 }
+.zoom-controls__label {
+  color: var(--text-muted);
+}
 
 /* ── DETAIL VIEW ── */
 .detail-view {
@@ -793,4 +848,12 @@ body::after {
 .detail-item-label {
   color: var(--text);
   font-weight: 500;
+}
+.detail-item__meta {
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-left: 8px;
+}
+.detail-item--empty {
+  color: var(--text-muted);
 }

--- a/oia-site/src/views/about.ts
+++ b/oia-site/src/views/about.ts
@@ -19,14 +19,14 @@ export function renderAboutView(): HTMLElement {
         </p>
       </div>
 
-      <div class="page-view__audience" style="margin-bottom: 40px;">
+      <div class="page-view__audience page-view__audience--section-gap">
         <span class="page-view__audience-item">enterprise search</span>
         <span class="page-view__audience-item">knowledge systems</span>
         <span class="page-view__audience-item">AI-supported information architectures</span>
         <span class="page-view__audience-item">large organizational information landscapes</span>
       </div>
 
-      <p class="page-view__body page-view__manifesto" style="margin-bottom: 48px;">
+      <p class="page-view__body page-view__manifesto page-view__manifesto--flow-bottom">
         Across different projects one question kept coming back:<br><br>
         <strong>How can organizations turn their knowledge into coordinated action?</strong><br><br>
         Not occasionally — but systematically.
@@ -34,19 +34,19 @@ export function renderAboutView(): HTMLElement {
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">Where the idea for OIA comes from</h2>
-        <p class="page-view__body" style="margin-bottom: 16px;">
+        <p class="page-view__body page-view__body--spaced-sm">
           In many organizations the situation looks similar.
         </p>
-        <p class="page-view__body" style="margin-bottom: 16px;">
+        <p class="page-view__body page-view__body--spaced-sm">
           Information exists everywhere — documents, systems, teams, expert knowledge in people's heads.
           Technology keeps improving. Yet decisions are still often made by <strong>manually piecing
           information together</strong>.
         </p>
-        <p class="page-view__body" style="margin-bottom: 16px;">
+        <p class="page-view__body page-view__body--spaced-sm">
           The issue is rarely missing data.<br>
           More often it is <strong>missing architecture</strong>.
         </p>
-        <p class="page-view__body" style="margin-bottom: 20px;">
+        <p class="page-view__body page-view__body--spaced">
           Architecture that connects:
         </p>
         <div class="page-view__flow page-view__flow--vertical">
@@ -60,20 +60,20 @@ export function renderAboutView(): HTMLElement {
           <span class="page-view__flow-arrow">→</span>
           <span class="page-view__flow-step accent3">action</span>
         </div>
-        <p class="page-view__body" style="margin-top: 20px; font-style: italic; color: var(--text-muted);">
+        <p class="page-view__body page-view__body--footnote">
           OIA started as an attempt to describe this architecture.
         </p>
       </section>
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">Practice before theory</h2>
-        <p class="page-view__body" style="margin-bottom: 16px;">
+        <p class="page-view__body page-view__body--spaced-sm">
           The ideas behind OIA did not start as a framework.
         </p>
-        <p class="page-view__body" style="margin-bottom: 16px;">
+        <p class="page-view__body page-view__body--spaced-sm">
           They emerged from practical work on:
         </p>
-        <div class="page-view__card" style="margin-bottom: 20px;">
+        <div class="page-view__card page-view__card--spaced">
           <ul class="page-view__card-list">
             <li>enterprise search systems</li>
             <li>knowledge platforms</li>
@@ -90,20 +90,20 @@ export function renderAboutView(): HTMLElement {
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">Why this project is open</h2>
-        <p class="page-view__body" style="margin-bottom: 16px;">
+        <p class="page-view__body page-view__body--spaced-sm">
           OIA is published as an open project because this problem is not specific to a single company.
         </p>
-        <p class="page-view__body" style="margin-bottom: 16px;">
+        <p class="page-view__body page-view__body--spaced-sm">
           Many organizations are currently trying to understand:
         </p>
-        <div class="page-view__card" style="margin-bottom: 20px;">
+        <div class="page-view__card page-view__card--spaced">
           <ul class="page-view__card-list">
             <li>how AI fits into existing information systems</li>
             <li>how organizational knowledge can be structured</li>
             <li>how humans and AI collaborate around knowledge</li>
           </ul>
         </div>
-        <p class="page-view__body" style="font-style: italic; color: var(--text-muted);">
+        <p class="page-view__body page-view__body--note">
           No single team will solve this alone.<br>
           The architecture will improve through shared experience.
         </p>
@@ -111,27 +111,27 @@ export function renderAboutView(): HTMLElement {
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">About this site</h2>
-        <p class="page-view__body" style="margin-bottom: 16px;">
+        <p class="page-view__body page-view__body--spaced-sm">
           This site hosts the evolving <strong>Organizational Intelligence Architecture (OIA)</strong> model.
         </p>
-        <p class="page-view__body" style="margin-bottom: 16px;">
+        <p class="page-view__body page-view__body--spaced-sm">
           The goal is to develop:
         </p>
-        <div class="page-view__card" style="margin-bottom: 20px;">
+        <div class="page-view__card page-view__card--spaced">
           <ul class="page-view__card-list">
             <li>a conceptual architecture</li>
             <li>practical patterns</li>
             <li>and eventually reference implementations</li>
           </ul>
         </div>
-        <p class="page-view__body" style="font-style: italic; color: var(--text-muted);">
+        <p class="page-view__body page-view__body--note">
           for organizations that want to turn knowledge into action.
         </p>
       </section>
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">Contact</h2>
-        <p class="page-view__body" style="margin-bottom: 12px;">
+        <p class="page-view__body page-view__body--spaced-xs">
           If you work on similar problems or want to discuss ideas around organizational intelligence,
           feel free to reach out.
         </p>

--- a/oia-site/src/views/contribute.ts
+++ b/oia-site/src/views/contribute.ts
@@ -61,7 +61,7 @@ export function renderContributeView(): HTMLElement {
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">Ways to Contribute</h2>
-        <p class="page-view__body" style="margin-bottom: 20px;">
+        <p class="page-view__body page-view__body--spaced">
           Contributions do not have to be large.<br>
           The most valuable inputs often come from real experience:
         </p>
@@ -81,7 +81,7 @@ export function renderContributeView(): HTMLElement {
             </ul>
           </div>
         </div>
-        <p class="page-view__body" style="margin-top: 20px; font-style: italic; color: var(--text-muted);">
+        <p class="page-view__body page-view__body--footnote">
           <a class="page-view__link" href="https://github.com/ruKurz/oi-architecture/issues" target="_blank" rel="noopener">A comment on an issue is a contribution.</a><br>
           <a class="page-view__link" href="https://www.linkedin.com/feed/update/urn:li:activity:7434972082561687552/" target="_blank" rel="noopener">A conversation that improves a concept is a contribution.</a>
         </p>
@@ -94,7 +94,7 @@ export function renderContributeView(): HTMLElement {
           <span class="page-view__contributing-cta-label">Read the full contribution guide</span>
           <span class="page-view__contributing-cta-file">CONTRIBUTING.md →</span>
         </a>
-        <div class="page-view__join-steps" style="margin-top: 24px;">
+        <div class="page-view__join-steps page-view__join-steps--top-gap">
           <div class="page-view__join-step">
             <span class="page-view__step-num">01</span>
             <div>
@@ -121,7 +121,7 @@ export function renderContributeView(): HTMLElement {
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">What We Value in Contributions</h2>
-        <p class="page-view__body" style="margin-bottom: 20px;">
+        <p class="page-view__body page-view__body--spaced">
           OIA is a <strong>practical architecture</strong>, not an academic framework.
         </p>
         <div class="page-view__cards">
@@ -140,7 +140,7 @@ export function renderContributeView(): HTMLElement {
             </ul>
           </div>
         </div>
-        <p class="page-view__body page-view__manifesto" style="margin-top: 28px;">
+        <p class="page-view__body page-view__manifesto page-view__manifesto--top-spaced">
           <strong>Architecture grows from practice.</strong><br>
           Failure is data. Share it.
         </p>
@@ -148,11 +148,11 @@ export function renderContributeView(): HTMLElement {
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">Start the Conversation</h2>
-        <p class="page-view__body" style="margin-bottom: 20px;">
+        <p class="page-view__body page-view__body--spaced">
           If you are building systems where <strong>knowledge must become action</strong>,<br>
           your experience belongs in this architecture.
         </p>
-        <p class="page-view__body" style="margin-bottom: 28px;">
+        <p class="page-view__body page-view__body--spaced-lg">
           Open an issue. Ask a question. Challenge an assumption.<br>
           Every conversation that improves the model is a contribution.
         </p>

--- a/oia-site/src/views/detail.ts
+++ b/oia-site/src/views/detail.ts
@@ -14,13 +14,13 @@ function renderChildren(model: OIAModel, ids: string[], depth = 0): string {
             : ''
         return `<div class="detail-item"${indent}>
         <span class="detail-item-label">${el.label}</span>
-        <span style="font-size:10px;color:var(--text-muted);margin-left:8px">${el.containerType}</span>
+        <span class="detail-item__meta">${el.containerType}</span>
         ${sub}
       </div>`
       }
       return `<div class="detail-item"${indent}>
       <span class="detail-item-label">${el.icon ? el.icon + ' ' : ''}${el.label}</span>
-      <span style="font-size:10px;color:var(--text-muted);margin-left:8px">${el.itemType}</span>
+      <span class="detail-item__meta">${el.itemType}</span>
     </div>`
     })
     .join('')
@@ -49,7 +49,7 @@ export function renderDetailView(model: OIAModel, id: string): HTMLElement {
     <div class="detail-title">${el.label}</div>
     ${description ? `<div class="detail-desc">${description}</div>` : ''}
     <div class="detail-items">
-      ${children.length > 0 ? renderChildren(model, children) : '<div class="detail-item" style="color:var(--text-muted)">No sub-elements</div>'}
+      ${children.length > 0 ? renderChildren(model, children) : '<div class="detail-item detail-item--empty">No sub-elements</div>'}
     </div>
   `
   return view

--- a/oia-site/src/views/legal.ts
+++ b/oia-site/src/views/legal.ts
@@ -33,13 +33,13 @@ export function renderLegalView(): HTMLElement {
         <h2 class="page-view__section-title">Verantwortlich für den Inhalt</h2>
         <p class="page-view__body">
           Rüdiger Kurz, Anschrift wie oben.<br>
-          <span style="color: var(--text-muted); font-size: 12px;">§ 55 Abs. 2 RStV</span>
+          <span class="page-view__legal-ref">§ 55 Abs. 2 RStV</span>
         </p>
       </section>
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">Lizenz</h2>
-        <p class="page-view__body" style="margin-bottom: 16px;">
+        <p class="page-view__body page-view__body--spaced-sm">
           Diese Seite veröffentlicht das <strong>Organizational Intelligence Architecture (OIA)</strong> Modell
           unter einer dualen Lizenz:
         </p>
@@ -55,7 +55,7 @@ export function renderLegalView(): HTMLElement {
             </li>
           </ul>
         </div>
-        <p class="page-view__body" style="margin-top: 16px; font-size: 13px; color: var(--text-muted);">
+        <p class="page-view__body page-view__body--caption">
           CC BY 4.0: Weitergabe und Bearbeitung erlaubt, solange der Urheber (Rüdiger Kurz)
           und die Quelle (<a class="page-view__link" href="https://github.com/ruKurz/oi-architecture" target="_blank" rel="noopener">github.com/ruKurz/oi-architecture</a>) genannt werden.
         </p>
@@ -63,7 +63,7 @@ export function renderLegalView(): HTMLElement {
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">Datenschutz</h2>
-        <p class="page-view__body" style="color: var(--text-muted);">
+        <p class="page-view__body page-view__body--muted">
           Diese Seite verwendet keine Cookies, kein Tracking und keine Analyse-Werkzeuge.
           Es werden keine personenbezogenen Daten erhoben oder gespeichert.<br>
           Hosting: GitHub Pages.

--- a/oia-site/src/views/motivation.ts
+++ b/oia-site/src/views/motivation.ts
@@ -29,10 +29,10 @@ export function renderMotivationView(): HTMLElement {
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">An Open Architecture of Participation</h2>
-        <p class="page-view__body" style="margin-bottom: 20px;">
+        <p class="page-view__body page-view__body--spaced">
           OIA is designed as a <strong>shared architectural thinking model</strong>.
         </p>
-        <p class="page-view__body" style="margin-bottom: 20px;">
+        <p class="page-view__body page-view__body--spaced">
           It improves when people who actually build systems contribute their experience:
         </p>
         <div class="page-view__audience">
@@ -49,7 +49,7 @@ export function renderMotivationView(): HTMLElement {
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">What Contributions Look Like</h2>
-        <p class="page-view__body" style="margin-bottom: 20px;">
+        <p class="page-view__body page-view__body--spaced">
           Contributions do not have to be large.<br>
           The most valuable inputs often come from real implementation experience:
         </p>
@@ -69,7 +69,7 @@ export function renderMotivationView(): HTMLElement {
             </ul>
           </div>
         </div>
-        <p class="page-view__body" style="margin-top: 20px; font-style: italic; color: var(--text-muted);">
+        <p class="page-view__body page-view__body--footnote">
           Real systems create real learning.<br>
           That learning improves the architecture.
         </p>
@@ -77,7 +77,7 @@ export function renderMotivationView(): HTMLElement {
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">From Reference Model to Real Systems</h2>
-        <p class="page-view__body" style="margin-bottom: 20px;">
+        <p class="page-view__body page-view__body--spaced">
           The long-term ambition of OIA is to evolve step by step:
         </p>
         <div class="page-view__flow page-view__flow--vertical">
@@ -89,14 +89,14 @@ export function renderMotivationView(): HTMLElement {
           <span class="page-view__flow-arrow">→</span>
           <span class="page-view__flow-step accent3">Operational Organizational Intelligence Systems</span>
         </div>
-        <p class="page-view__body" style="margin-top: 20px; font-style: italic; color: var(--text-muted);">
+        <p class="page-view__body page-view__body--footnote">
           This evolution can only happen through <strong>shared practice</strong>.
         </p>
       </section>
 
       <section class="page-view__section">
         <h2 class="page-view__section-title">Join the Work</h2>
-        <p class="page-view__body" style="margin-bottom: 20px;">
+        <p class="page-view__body page-view__body--spaced">
           If you are building systems where <strong>knowledge must become action</strong>,<br>
           your experience belongs in this architecture.
         </p>
@@ -114,7 +114,7 @@ export function renderMotivationView(): HTMLElement {
             <span>Contribute insights from real implementations</span>
           </div>
         </div>
-        <p class="page-view__body page-view__manifesto" style="margin-top: 28px;">
+        <p class="page-view__body page-view__manifesto page-view__manifesto--top-spaced">
           OIA is not a finished answer.<br><br>
           It is a place where the architecture of organizational intelligence is <strong>built in the open</strong>.
         </p>


### PR DESCRIPTION
## Summary

- Adds 16 BEM modifier classes to `layout.css` (body spacing variants, component modifiers, detail/zoom helpers)
- Replaces all 43 fixable `style=` attributes across `about.ts`, `contribute.ts`, `motivation.ts`, `legal.ts`, `detail.ts`, `router.ts`
- Updates CONVENTIONS.md Known Exceptions: removes resolved #132 entry, documents `detail.ts:9` dynamic `margin-left` as legitimate exception

**Known exception kept:** `detail.ts:9` — `margin-left:${depth * 16}px` is computed indentation that cannot be expressed as a static CSS class.

## Test plan

- [x] `npm run build` — clean build (22.12 kB CSS, 55.59 kB JS)
- [x] `npm test` — 61/61 passing

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)