### PR TITLE
chore(process): sprint retro improvements — 2026-03-15

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ Read before every session:
 
 Sprint process entry point: `prompts/development/sprint-change.md` — orchestrates review, retro, planning, refinement, scope-change.
 
+**Mid-sprint scope rule:** Any issue added to an active sprint after the planning handshake must be processed via `prompts/development/sprint-scope-change.md`. Do not add issues to the sprint file directly without running this prompt.
+
 Read when working with decision records:
 - `context/adr-concept.md` — what ADRs are, canonical references, ADR vs ODR distinction
 - `context/odr-concept.md` — full ODR concept, derivation chain, lifecycle, agent onboarding

--- a/prompts/templates/prompt-helper.md
+++ b/prompts/templates/prompt-helper.md
@@ -151,6 +151,12 @@ You are finished when:
 - [ ] `Constraints` are explicitly stated (not just implied)
 - [ ] `Acceptance criteria` are measurable (not "looks good")
 - [ ] No project context is repeated inline — path references only
+- [ ] Prompt compliance pre-flight passed — run before committing:
+  ```bash
+  for section in "## Context" "## Goal" "## Constraints" "## Acceptance criteria"; do
+    grep -q "$section" <path-to-prompt>.md && echo "OK: $section" || echo "MISSING: $section"
+  done
+  ```
 - [ ] The prompt is saved at the following path:
 
 ```


### PR DESCRIPTION
## Summary

Two process improvements from the sprint retro #159:

**Measure 1 — `prompts/templates/prompt-helper.md`**
Added a prompt compliance pre-flight grep step to the Done checklist. Before committing any new or modified prompt, the four mandatory sections (`## Context`, `## Goal`, `## Constraints`, `## Acceptance criteria`) are verified locally. Prevents a repeat of the CI block on PRs #153–156.

**Measure 2 — `CLAUDE.md`**
Added a mid-sprint scope rule under the sprint process entry point: any issue added after the planning handshake must go through `sprint-scope-change.md`. Eliminates the ad-hoc direct sprint file edits that happened in sprint 2026-03-15.

## Acceptance criteria

- [x] `prompt-helper.md` Done checklist includes local compliance grep step
- [x] `CLAUDE.md` references `sprint-scope-change.md` for mid-sprint scope additions

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)