### PR TITLE
content(model): replace Actors layer with System Participants (#34)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Official tasks: GitHub Issues at https://github.com/ruKurz/oi-architecture/issue
 
 ## Version Identity
 
-**Current OIA version: `0.1.0`**
+**Current OIA version: `0.2.0`**
 
 This version string must be consistent everywhere it appears:
 - `oia-site/src/data/oia-model.json` → `meta.version`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > *How organizations turn knowledge into action.*
 
-**[Live Demo →](https://rukurz.github.io/oi-architecture/)** | Version 0.1.0 — early access | [![CI](https://github.com/ruKurz/oi-architecture/actions/workflows/pr-check.yml/badge.svg)](https://github.com/ruKurz/oi-architecture/actions/workflows/pr-check.yml)
+**[Live Demo →](https://rukurz.github.io/oi-architecture/)** | Version 0.2.0 — early access | [![CI](https://github.com/ruKurz/oi-architecture/actions/workflows/pr-check.yml/badge.svg)](https://github.com/ruKurz/oi-architecture/actions/workflows/pr-check.yml)
 
 **OIA** is a conceptual reference model for intelligent organizations.
 It describes how raw data becomes decisions, actions, and measurable business outcomes — going beyond pure data and analytics architectures.

--- a/oia-site/src/data/oia-model.json
+++ b/oia-site/src/data/oia-model.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "version": "0.1.0",
+    "version": "0.2.0",
     "title": "Organizational Intelligence Architecture",
     "subtitle": "How organizations turn knowledge into action",
     "created": "2026"
@@ -119,77 +119,137 @@
       "id": "#L9",
       "type": "container",
       "containerType": "layer",
-      "label": "Actors",
-      "description": "Who interacts with the system",
-      "children": ["#L9-users", "#L9-agents"],
+      "label": "System Participants",
+      "description": "Who initiates, acts, and benefits — and with what accountability",
+      "children": [
+        "#L9-triad",
+        "#L9-spectrum-autonomy",
+        "#L9-spectrum-accountability",
+        "#L9-key-insight"
+      ],
       "meta": { "order": 9 }
     },
     {
-      "id": "#L9-users",
+      "id": "#L9-triad",
       "type": "container",
       "containerType": "frame",
-      "label": "Users",
-      "badges": ["badge-feedback"],
-      "meta": { "icon": "👤", "variant": "users" },
-      "children": ["#L9-u1", "#L9-u2", "#L9-u3", "#L9-u4"]
+      "label": "Triad",
+      "children": ["#L9-t-initiator", "#L9-t-actor", "#L9-t-beneficiary"]
     },
     {
-      "id": "#L9-u1",
+      "id": "#L9-t-initiator",
       "type": "item",
-      "itemType": "actor",
-      "label": "Employees",
-      "properties": { "role": "human" }
+      "itemType": "participant",
+      "label": "Initiator",
+      "role": "initiator",
+      "triadPosition": 1,
+      "color": "purple",
+      "weight": "secondary"
     },
     {
-      "id": "#L9-u2",
+      "id": "#L9-t-actor",
       "type": "item",
-      "itemType": "actor",
-      "label": "Developers",
-      "properties": { "role": "human" }
+      "itemType": "participant",
+      "label": "Actor",
+      "role": "actor",
+      "triadPosition": 2,
+      "color": "teal",
+      "weight": "primary",
+      "primary": true
     },
     {
-      "id": "#L9-u3",
+      "id": "#L9-t-beneficiary",
       "type": "item",
-      "itemType": "actor",
-      "label": "Analysts",
-      "properties": { "role": "human" }
+      "itemType": "participant",
+      "label": "Beneficiary",
+      "role": "beneficiary",
+      "triadPosition": 3,
+      "color": "amber",
+      "weight": "secondary"
     },
     {
-      "id": "#L9-u4",
-      "type": "item",
-      "itemType": "actor",
-      "label": "Decision Makers",
-      "properties": { "role": "human" }
-    },
-    {
-      "id": "#L9-agents",
+      "id": "#L9-spectrum-autonomy",
       "type": "container",
-      "containerType": "frame",
-      "label": "Agents",
-      "badges": ["badge-feedback"],
-      "meta": { "icon": "🤖", "variant": "agents" },
-      "children": ["#L9-a1", "#L9-a2", "#L9-a3"]
+      "containerType": "spectrum",
+      "label": "Autonomy & Decision Space",
+      "spectrumAxis": "autonomy",
+      "children": ["#L9-sa-system", "#L9-sa-human", "#L9-sa-agent"]
     },
     {
-      "id": "#L9-a1",
+      "id": "#L9-sa-system",
       "type": "item",
-      "itemType": "actor",
-      "label": "AI Assistants",
-      "properties": { "role": "agent" }
+      "itemType": "participant",
+      "label": "System",
+      "spectrumAxis": "autonomy",
+      "position": 1,
+      "description": "Configured · deterministic",
+      "color": "gray"
     },
     {
-      "id": "#L9-a2",
+      "id": "#L9-sa-human",
       "type": "item",
-      "itemType": "actor",
-      "label": "AI Agents",
-      "properties": { "role": "agent" }
+      "itemType": "participant",
+      "label": "Human",
+      "spectrumAxis": "autonomy",
+      "position": 2,
+      "description": "Guided · contextual judgment",
+      "color": "teal"
     },
     {
-      "id": "#L9-a3",
+      "id": "#L9-sa-agent",
       "type": "item",
-      "itemType": "actor",
-      "label": "Autonomous Systems",
-      "properties": { "role": "agent" }
+      "itemType": "participant",
+      "label": "Agent",
+      "spectrumAxis": "autonomy",
+      "position": 3,
+      "description": "Goal-directed · autonomous",
+      "color": "teal",
+      "converging": true
+    },
+    {
+      "id": "#L9-spectrum-accountability",
+      "type": "container",
+      "containerType": "spectrum",
+      "label": "Accountability",
+      "spectrumAxis": "accountability",
+      "children": ["#L9-sc-system", "#L9-sc-agent", "#L9-sc-human"]
+    },
+    {
+      "id": "#L9-sc-system",
+      "type": "item",
+      "itemType": "participant",
+      "label": "System",
+      "spectrumAxis": "accountability",
+      "position": 1,
+      "description": "Inherits from Initiator",
+      "color": "gray"
+    },
+    {
+      "id": "#L9-sc-agent",
+      "type": "item",
+      "itemType": "participant",
+      "label": "Agent",
+      "spectrumAxis": "accountability",
+      "position": 2,
+      "description": "ODR-bounded · delegated",
+      "color": "teal"
+    },
+    {
+      "id": "#L9-sc-human",
+      "type": "item",
+      "itemType": "participant",
+      "label": "Human",
+      "spectrumAxis": "accountability",
+      "position": 3,
+      "description": "Legal · structural · always",
+      "color": "purple"
+    },
+    {
+      "id": "#L9-key-insight",
+      "type": "item",
+      "itemType": "keyInsight",
+      "label": "Key Insight",
+      "text": "Capabilities converge. Accountability does not. The human remains the legal and structural anchor — independent of agent autonomy."
     },
 
     {
@@ -908,18 +968,10 @@
     },
     {
       "id": "conn-fb-2",
-      "from": "#L9-agents",
+      "from": "#L9",
       "to": "#L3",
       "connectionType": "feedback",
-      "label": "Agents → Knowledge Core",
-      "direction": "backward"
-    },
-    {
-      "id": "conn-fb-3",
-      "from": "#L9-users",
-      "to": "#L3",
-      "connectionType": "feedback",
-      "label": "Users → Knowledge Core",
+      "label": "System Participants → Knowledge Core",
       "direction": "backward"
     },
     {

--- a/oia-site/src/views/contribute.ts
+++ b/oia-site/src/views/contribute.ts
@@ -18,7 +18,7 @@ export function renderContributeView(): HTMLElement {
       <div class="page-view__intro">
         <p>OIA is not a finished framework.</p>
         <p>
-          It is a <strong>working model</strong> — version <strong>0.1.0</strong>, intentionally early.
+          It is a <strong>working model</strong> — version <strong>0.2.0</strong>, intentionally early.
         </p>
         <p>
           The architecture will evolve through real implementations, experiments, and operational feedback.<br>

--- a/oia-site/src/views/motivation.ts
+++ b/oia-site/src/views/motivation.ts
@@ -21,7 +21,7 @@ export function renderMotivationView(): HTMLElement {
           It is a <strong>working model</strong> for how organizations can turn knowledge into action.
         </p>
         <p>
-          Version <strong>0.1.0</strong> is intentionally early.<br>
+          Version <strong>0.2.0</strong> is intentionally early.<br>
           The architecture will evolve through real implementations, experiments and operational feedback.
         </p>
         <p>Not through theory alone.</p>

--- a/oia-site/tests/views.spec.ts
+++ b/oia-site/tests/views.spec.ts
@@ -86,10 +86,10 @@ describe('renderMotivationView', () => {
     expect(el.querySelector('.page-view__eyebrow')?.textContent?.trim()).toBe('Motivation')
   })
 
-  test('contains version number 0.1.0', async () => {
+  test('contains version number 0.2.0', async () => {
     const { renderMotivationView } = await import('../src/views/motivation')
     const el = renderMotivationView()
-    expect(el.innerHTML).toContain('0.1.0')
+    expect(el.innerHTML).toContain('0.2.0')
   })
 
   test('contains at least one section', async () => {


### PR DESCRIPTION
## Summary

- Replaces `#L9` ("Actors") with the System Participants layer as specified in OIA-ODR-0001
- New structure: **Triad** (Initiator/Actor/Beneficiary) + **Spectrum 1** (Autonomy: System→Human→Agent) + **Spectrum 2** (Accountability: System→Agent→Human) + **Key Insight** block
- Bumps version `0.1.0` → `0.2.0` across all 5 locations (oia-model.json, contribute.ts, motivation.ts, README.md, CLAUDE.md)
- Stale `#L9-users` and `#L9-agents` feedback connections merged into single `#L9 → #L3` connection

## Data model additions

New fields used in `#L9` children:
- `role` + `triadPosition` + `weight` + `primary` (triad items)
- `spectrumAxis` + `position` + `converging` (spectrum items — `converging: true` on `#L9-sa-agent` signals dashed connector)
- `itemType: "keyInsight"` + `text` (key insight item)

## Test plan

- [x] `npm test` — 61 tests pass
- [x] `npm run build` — clean build
- [ ] Visual review in browser (renderer for `#L9` is a custom component, tracked in #161 — no visual regression expected until #161 is implemented)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)