### PR TITLE
fix(infra): patch undici vulnerability + add audit to PR Check (#171)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install dependencies
         run: cd oia-site && npm ci
 
+      - name: Security audit
+        run: cd oia-site && npm audit --audit-level=moderate
+
       - name: Lint
         run: cd oia-site && npm run lint
 

--- a/oia-site/package-lock.json
+++ b/oia-site/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oia-site",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oia-site",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@vitest/ui": "^4.0.18",
@@ -3446,9 +3446,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
+      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- `npm audit fix` patches 6 high-severity undici CVEs (transitive dependency)
- `npm audit --audit-level=moderate` added to `pr-check.yml` — vulnerabilities now caught before merge to main, not after

## Root cause

Audit ran only in `deploy.yml`. PRs could pass all checks and land in main without triggering the audit gate, causing the deploy to fail post-merge.

## Test plan

- [ ] PR Check passes (audit step green)
- [ ] Merge unblocks deploy to GitHub Pages

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)