### PR TITLE
feat(prompt): add skill oia-issue-implementieren (#174)

### DIFF
--- a/prompts/skills/oia-issue-implementieren/SKILL.md
+++ b/prompts/skills/oia-issue-implementieren/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: oia-issue-implementieren
+description: >-
+  Implement a GitHub Issue from the oi-architecture tracker.
+  Use when given an issue number or URL to implement.
+  Covers BIZ and DEV tasks, branch workflow, commit conventions,
+  and PR creation per project rules.
+  Trigger explicitly with: "use skill oia-issue-implementieren for #N"
+  or implicitly when asked to implement a specific issue number.
+---
+
+# oia-issue-implementieren
+
+Workflow for implementing a GitHub Issue in the oi-architecture project.
+Execute the following steps in order.
+
+---
+
+## 1. Pre-flight
+
+1. Read the issue: `gh issue view #N`
+2. Identify domain: **BIZ** or **DEV** — see `references/CONVENTIONS.md` §2.1
+   - BIZ: `context/` `articles/` `diagrams/` `decisions/` `.local/notes/`
+   - DEV: `oia-site/` `.github/` `prompts/` + root files
+3. Check for blocked-by dependencies in the issue body. Stop and notify
+   the human if a blocking issue is not yet resolved.
+4. Confirm current branch: `git branch --show-current`
+   Switch to `main` and pull before branching.
+
+---
+
+## 2. Branch
+
+```
+git checkout main && git pull
+git checkout -b feature/#N-short-description
+```
+
+Branch prefix rules (from ADR-0014):
+- `feature/#N-` — new functionality
+- `fix/#N-` — bug fix
+- `chore/#N-` — maintenance, dependency updates
+- `docs/#N-` — documentation only
+- `content/#N-` — BIZ content changes
+
+---
+
+## 3. Implement
+
+- **YAGNI:** implement only what the Acceptance Criteria require.
+- **BIZ/DEV boundary:** a single commit touches either BIZ or DEV — never both.
+  If both are needed: two separate commits.
+- **Never** touch BIZ artifacts (`context/`, `decisions/`, `diagrams/`) during a DEV task.
+- **Prompts:** any change to `prompts/` requires the prompt-helper process
+  (see CLAUDE.md §No Prompt Without Helper). Refuse and redirect if skipped.
+
+Check `references/decisions-README.md` if an ADR or ODR is relevant to the
+change — do not contradict an Accepted record without a superseding record.
+
+---
+
+## 4. Commit
+
+Format: `type(scope): description (#N)`
+
+```
+git add <specific files>
+git commit -m "$(cat <<'EOF'
+type(scope): short description (#N)
+
+Longer explanation if needed.
+
+Closes #N
+EOF
+)"
+```
+
+- Subject line ≤ 72 characters
+- Footer: `Closes #N` (if the commit fully resolves the issue)
+  or `Refs #N` (partial progress)
+- Commit type must match domain: BIZ → `content:` / `docs:`, DEV → `feat:` / `fix:` / `chore:` etc.
+- Full type list and scope examples: `references/CONVENTIONS.md` §2.3
+
+---
+
+## 5. PR
+
+1. Push the branch (notify human in chat first — per project push rules):
+   ```
+   git push -u origin feature/#N-short-description
+   ```
+2. Open PR:
+   ```
+   gh pr create --title "type(scope): description (#N)" --body "..."
+   ```
+3. Summarize the PR in chat and **wait for human approval** before merging.
+   Never merge to `main` directly.

--- a/prompts/skills/oia-issue-implementieren/references/CONVENTIONS.md
+++ b/prompts/skills/oia-issue-implementieren/references/CONVENTIONS.md
@@ -1,0 +1,409 @@
+# OIA · Project Conventions
+
+> Decision Log for Future Me — binding rules for all new files and commits.
+> Existing files are not retroactively adjusted. New files follow these conventions immediately.
+
+---
+
+## 2.1 BIZ / DEV Separation
+
+Two distinct domains. A commit touches exactly one.
+
+| Domain | Meaning | Commit Types | Folders / Files |
+|---|---|---|---|
+| **DEV** | Technical implementation: Renderer, Tooling, Tests, Build, CI | `feat:` `fix:` `chore:` `refactor:` `test:` `style:` | `oia-site/` `.github/` `prompts/` + root files: `CLAUDE.md` `CONVENTIONS.md` `README.md` `CHANGELOG.md` `SECURITY.md` `CODE_OF_CONDUCT.md` `.gitmessage` |
+| **BIZ** | Domain content: OIA model, articles, diagram content, architecture decisions | `content:` `docs:` | `context/` `articles/` `diagrams/` `decisions/` `.local/notes/` |
+
+**Rule:** A single commit touches either BIZ or DEV — never both. If both are needed: two separate commits.
+
+**Root-file rule:** Root-level files (`CLAUDE.md`, `CONVENTIONS.md`, `README.md`, etc.) are DEV. A commit that updates `decisions/` (BIZ) must not also update `CLAUDE.md` or `README.md` — that requires a second DEV commit.
+
+**Rule:** No commit without a referenced GitHub Issue (except: `chore: initial setup` for new files).
+
+See [ADR-0002](decisions/adr/0002-biz-dev-separation.md) for rationale.
+
+---
+
+## 2.2 Language
+
+**Rule:** All project artifacts are written in English. The only exception is LinkedIn articles, which remain in German for a German-speaking audience.
+
+| Context | Language | Examples |
+|---|---|---|
+| Code, comments, commits, filenames | English | `renderLayerAsHtml()`, `feat: add zoom constants` |
+| Types, interfaces, JSON keys | English | `ContentItem`, `itemType`, `containerType` |
+| ADRs | English | `ADR-0011: English as the Sole Project Language` |
+| Prompts | English | `prompts/development/integrate-concept.md` |
+| Context files, notes, documentation | English | `context/oia-context.md`, `docs/` |
+| LinkedIn articles | German | Author's choice for German-speaking audience |
+
+Existing German files in `context/`, `notes/`, and `prompts/` are known exceptions — not retroactively translated; follow English on creation or next significant edit.
+
+See [ODR-0004](decisions/odr/0004-english-as-project-language.md) for rationale.
+
+---
+
+## 2.3 Conventional Commits
+
+Format:
+```
+<type>[optional scope]: <imperative description> (#N)
+
+[optional body, wrapped at 72 chars]
+
+Closes #N   ← closes the GitHub Issue
+Refs #N     ← references without closing (for partial work)
+```
+
+The `(#N)` suffix in the subject line makes the issue reference visible in `git log --oneline`. The footer `Closes #N` is kept alongside it — it is needed for GitHub auto-close and changelog tooling. See [ADR-0013](decisions/adr/0013-issue-reference-in-commit-subject.md) for rationale.
+
+Allowed types:
+
+| Type | Usage |
+|---|---|
+| `feat` | New feature in renderer or tooling |
+| `fix` | Bug fix |
+| `content` | New OIA content, article, model addition (BIZ) |
+| `docs` | Documentation, ADRs, CONVENTIONS.md |
+| `refactor` | Code restructuring without behavior change |
+| `test` | Tests added or adjusted |
+| `chore` | Build, CI/CD, dependencies, tooling |
+| `style` | Formatting (no logic change) |
+
+Scopes (optional, in parentheses):
+```
+feat(renderer): add outcome layer rendering
+content(model): add business outcome items to L10
+chore(ci): add npm audit to deploy pipeline
+```
+
+Rules:
+- Imperative: "add" not "added", "fix" not "fixes"
+- Max 50 characters for subject line (the `(#N)` suffix counts toward this)
+- No period at end
+- `(#N)` suffix in subject line — always (except initial commits)
+- GitHub Issue in footer — always (except initial commits)
+- Before `Closes #N`: all acceptance criteria of the issue must be verified — see §2.4 Close-Verifikation
+
+See [ADR-0005](decisions/adr/0005-conventional-commits-with-content-type.md) for rationale.
+
+---
+
+## 2.4 Issue Tracking
+
+**Official tasks → GitHub Issues** (https://github.com/ruedigerk/oi-architecture/issues)
+
+Benefits: community-ready, filterable, linkable in commits, milestone-capable.
+
+`context/todo.md` remains as **Session Parking Lot** — observations captured during work that are not yet prioritized. Before starting work: convert open parking-lot entries to GitHub Issues or explicitly discard them.
+
+Parking-lot entry format (in `context/todo.md`):
+```
+**[YYYY-MM-DD] [ACTION] `#category` [S|M|L]** (DEV|BIZ)
+→ Affected path: Description
+→ Action: What specifically to do
+```
+
+Categories: `model` · `renderer` · `prompt` · `architecture` · `infra` · `ux` · `content`
+
+See [ADR-0003](decisions/adr/0003-github-issues-as-task-tracker.md) for rationale.
+
+### No-Duplicate Rule
+
+**Every workflow that creates GitHub Issues must run the duplicate check first — without exception.**
+
+This applies to all prompts, scripts, and AI-assisted workflows:
+
+1. Load open issues: `gh issue list --state open --limit 100`
+2. Check for overlap by **title keywords** and **affected file/component**.
+3. Clear overlap → **do not create** — reference the existing issue instead.
+4. Uncertain → create the issue and add `possibly related to #N` in the body.
+
+This rule is authoritative here. All prompts that create issues must reference it by name (`CONVENTIONS.md §2.4 No-Duplicate Rule`) rather than repeating the procedure inline. See [ADR-0003](decisions/adr/0003-github-issues-as-task-tracker.md) for the original definition and rationale.
+
+### Issue closing rules
+
+**Close-Verifikation:** When closing an issue, the close comment must verify each AC item explicitly:
+
+```
+gh issue close <N> --comment "Closed: implemented in commit <HASH> — <COMMIT_TITLE>
+
+AC verified:
+✅ Criterion A
+✅ Criterion B
+⚠️ Criterion C: deferred to #M"
+```
+
+**AC-Update bei Scope-Änderung:** If scope changes during implementation (e.g. a file path changes, a feature is split), update the issue's Acceptance criteria before closing — not after.
+
+**Externe Abhängigkeiten:** AC items that depend on another open issue must be marked `blocked by #N` in the AC list, not listed as standalone criteria. This prevents false-negative reviews at close time.
+
+**Post-deploy AC items:** AC items that require a deployed environment (visual layout checks, live-site verification) must be marked `(post-deploy)` explicitly. They may be verified after the PR is merged and deployment is complete — they do not block the PR merge.
+
+Example:
+```
+✅ Criterion A
+✅ Criterion B
+⚠️ Criterion C (post-deploy): visual layout check — verify after deployment
+```
+
+**Cross-cutting concept checklist:** When creating an issue for a new concept introduction (a new ADR category, a new documentation format, a new convention), the AC list must include an explicit review of all standard integration points. Either each point is covered in the issue, or explicitly excluded with a reason:
+
+| Integration point | Typical artifact |
+|---|---|
+| Agent instructions | `CLAUDE.md` |
+| Binding rules | `CONVENTIONS.md` |
+| Process prompts | `prompts/development/` |
+| CI validation | `.github/workflows/pr-check.yml` |
+| User-facing docs | `docs/` |
+| Repository entry points | `README.md`, `CONTRIBUTING.md` |
+| Change history | `CHANGELOG.md` |
+
+See [ADR-0014](decisions/adr/0014-feature-branch-release-branch-workflow.md) and sprint retro 2026-03-14 for rationale.
+
+---
+
+## 2.5 TypeScript Naming
+
+| Element | Convention | Example |
+|---|---|---|
+| Variables | camelCase, semantically complete | `currentZoomValue`, `diagramWrapperElement` |
+| Functions | camelCase, verb first, semantically complete | `renderLayerAsHtml()`, `findElementById()`, `resolveChildrenForContainer()` |
+| Booleans | `is`/`has` prefix | `isHighlighted`, `hasChildren`, `isDetailView` |
+| Event handlers | `on`/`handle` prefix | `onHashChange`, `handleZoomInput` |
+| Types/Interfaces | PascalCase, no `I`/`T` prefix | `OIAModel`, `ContentItem`, `LayerContainer` |
+| Enums (name) | PascalCase | `ContainerType` |
+| Enum values | SCREAMING_SNAKE_CASE | `SITUATION_LAYER`, `DATA_SOURCE` |
+| Constants (module-level) | SCREAMING_SNAKE_CASE | `DEFAULT_ZOOM`, `ZOOM_LEVELS` |
+| No type info in name | | `userString` ❌ → `userName` ✓ |
+| No abbreviations | | `el` ❌ → `element` ✓, `btn` ❌ → `button` ✓ |
+
+---
+
+## 2.6 File and Folder Naming
+
+| Type | Convention | Example |
+|---|---|---|
+| TypeScript modules | kebab-case | `render-layer.ts`, `oia-model.json` |
+| Test files | `<name>.spec.ts` | `render-layer.spec.ts` |
+| Directories | kebab-case, English | `src/renderer/`, `src/data/` |
+| Markdown content | kebab-case, English | `naming-conventions.md` |
+| Prompts | kebab-case, English | `introduce-conventions.md` |
+
+---
+
+## 2.7 CSS Classes
+
+kebab-case, BEM-lite (Block__Element only when hierarchy is semantically meaningful):
+
+```css
+.detail-view          /* Block */
+.detail-view__title   /* Element (only when hierarchy is semantically relevant) */
+.zoom-controls        /* simple block */
+.layer-core           /* modifier embedded in block name */
+```
+
+No inline styles for recurring values — always use CSS variable or class.
+
+---
+
+## 2.8 JSON Data Model (DEV structure)
+
+Keys: camelCase (JavaScript-idiomatic):
+```json
+{ "itemType": "outcome", "containerType": "layer", "isHighlighted": true }
+```
+
+IDs: Existing `#L1`–`#L10` are not changed. Schema for new items: BIZ decision (not defined here).
+
+---
+
+## 2.9 Tests
+
+```typescript
+describe('<FunctionName>', () => {
+  test('<verb> + <expected result>', ...)
+  // Examples:
+  test('returns element with class detail-view', ...)
+  test('shows not-found message for unknown id', ...)
+  test('renders badge icons on tagged layers', ...)
+})
+```
+
+**Browser-environment defaults:** When implementing logic that depends on browser properties (e.g. `window.innerWidth`, `window.innerHeight`), note the JSDOM default before writing tests (`innerWidth` defaults to `1024`, `innerHeight` to `768`) and confirm that test setup matches the implementation assumption.
+
+---
+
+## 2.10 Prompts
+
+Every new prompt file in `prompts/` must be created through the `prompts/templates/prompt-helper.md` process. Prompts without the required sections (`## Context`, `## Goal`, `## Constraints`, `## Acceptance criteria`) are non-compliant.
+
+See [ADR-0006](decisions/adr/0006-prompt-helper-enforcement.md) for rationale.
+
+---
+
+## 2.12 Concept Introduction
+
+When introducing a new concept into the project (a new documentation format, a new process, a new architectural pattern), the following order is mandatory:
+
+**Step 1 — Design first.** The concept must be fully designed and validated in collaboration with the human maintainer before any integration issues are created. The entry point is `prompts/development/integrate-concept.md`.
+
+**Step 2 — Create integration issues.** Only after the concept is stable: create GitHub Issues for each integration point (CONVENTIONS.md, CLAUDE.md, prompts, CI, docs, README, CHANGELOG, ...).
+
+**Step 3 — Implement integration.** Execute the issues in dependency order.
+
+**Rule:** Never start integration work before the concept design is complete. Starting integration on an unstable concept creates rework across all integration points.
+
+**Mandatory entry point:** `prompts/development/integrate-concept.md` — use it for every new concept introduction, without exception.
+
+---
+
+## 2.13 New Public Artifacts
+
+Before creating new top-level directories, new root-level files, or any other repository artifact that becomes public content, verify that an ADR or ODR covers the decision. If none exists: raise the question with the human maintainer first and block implementation until confirmed.
+
+**Rule:** Do not create public repository artifacts without a decision record authorizing them. If uncertain whether a record exists, check `decisions/README.md` first.
+
+---
+
+## ADR Format
+
+See [decisions/README.md](decisions/README.md) for the full ADR template and index.
+
+Methodology: Ralf D. Müller / Johannes Dienst — Decision first, Alternatives mandatory.
+
+**Location:** `decisions/adr/NNNN-kebab-case-title.md`
+
+**Required fields:** `Decision` · `Status` · `Date` · `Type` · `Governed by`
+
+**Governed by field:** Every ADR carries `**Governed by:** ODR-XXXX` pointing to the ODR that mandated it, or `**Governed by:** —` when no ODR applies. This field enables upward traversal from Arch → Org layer.
+
+**ADR Acceptance Rule:** Only a human maintainer may set an ADR status to `Accepted`. AI-assisted tooling must use `Proposed` when creating new ADRs. An ADR in `Proposed` state is active and followed — `Proposed` means "awaiting human sign-off", not "not yet in use".
+
+See [ADR-0004](decisions/adr/0004-adr-format-mueller-dienst.md) and [ODR-0003](decisions/odr/0003-adopt-adrs-as-arch-layer-documentation-practice.md) for rationale.
+
+---
+
+## ODR Format
+
+ODRs document organizational decisions at the Org layer of the governance hierarchy (Gov → Org → Arch). See [decisions/README.md](decisions/README.md) for the ODR index and [decisions/odr/odr-template.md](decisions/odr/odr-template.md) for the template.
+
+**Location:** `decisions/odr/NNNN-kebab-case-title.md`
+
+**Numbering:** ODR numbers are independent of ADR numbers. The next ODR number = current highest in the ODR index + 1. Never reuse a number.
+
+**Required fields:**
+
+| Field | Values | Purpose |
+|---|---|---|
+| `Decision` | One or two sentences, active voice | What was decided and why — upfront |
+| `Status` | `Proposed` · `Accepted` · `Deprecated` · `Superseded by ODR-XXXX` | Lifecycle state |
+| `Date` | `YYYY-MM-DD` | Date created |
+| `Level` | Always `Org` | Governance layer |
+| `Binding for` | `All` · `Users` · `Agents` · `Contributors` | Explicit scope |
+| `Derives from` | `ODR-XXXX` · `—` | Parent ODR in the derivation chain |
+| `Implements` | `ADR-XXXX, ADR-YYYY` · `—` | Arch-layer records that implement this ODR |
+
+**Bidirectional linking rule:**
+- ODR → ADR: via `Implements` field on the ODR
+- ADR → ODR: via `Governed by` field on the ADR
+- These two fields must be kept in sync when creating either record.
+
+**ODR Acceptance Rule:** Same as ADRs — only a human maintainer sets `Accepted`. AI tooling uses `Proposed`.
+
+**Commit type:** ODR changes use `docs(decisions):` — ODRs are BIZ artifacts stored in `decisions/odr/`.
+
+**Supersession:** When an ODR is superseded, move it to `decisions/_obsolete/` and update its status to `Superseded by ODR-XXXX`. Update the ODR index in `decisions/README.md` with a strikethrough entry.
+
+See [ODR-0000](decisions/odr/0000-commit-to-transparent-governance-documentation.md) and [context/odr-concept.md](context/odr-concept.md) for rationale and full concept.
+
+---
+
+## 2.11 Semantic Anchors
+
+Semantic Anchors are named methodologies invoked verbatim in prompts and CLAUDE.md to activate established knowledge domains in AI assistants. They complement ADRs: an ADR documents a project-specific decision, an anchor establishes shared vocabulary for a universal methodology.
+
+**Active anchor set:** `context/semantic-anchors.md`
+**Decision:** [ADR-0010](decisions/adr/0010-semantic-anchors-as-vocabulary-layer.md)
+
+Rules:
+- Anchors are invoked **verbatim** — "MECE Principle (Minto)", not "MECE" or "mutually exclusive"
+- New anchors must exist in the library at https://llm-coding.github.io/Semantic-Anchors/ or meet the same quality criteria (precise, rich, consistent, attributable)
+- Adding or removing an anchor requires a GitHub Issue and a `content(context):` commit
+- Project-specific rules belong in ADRs. Universal methodology vocabulary belongs in Semantic Anchors. Do not put methodology explanations in ADRs — reference the anchor instead
+
+---
+
+## Document Versioning
+
+**No document-internal version annotations.** Individual files do not carry a `**Version:**` field or version subtitle. Versioning is via Git history exclusively — `git log -- <file>` is the authoritative change record.
+
+**Exception:** `oia-site/src/data/oia-model.json → meta.version` — this is the OIA model's release version, consumed by the UI and tied to the project's SemVer release cycle (ADR-0007). It must not be removed.
+| `context/oia-project-instruction-prompt.md` | 1.0.0 |
+
+Update the version field and this table when making significant changes to a concept file.
+
+---
+
+## Git Workflow
+
+See [ADR-0014](decisions/adr/0014-feature-branch-release-branch-workflow.md) for rationale.
+
+### Branch Strategy
+
+Feature-branch per issue. No `develop` branch. Release branches for release preparation only.
+
+**Branch naming:**
+```
+feature/#42-add-zoom-constants
+fix/#78-deliver-capability
+docs/#98-semantic-versioning-adr
+release/v0.2.0
+```
+Pattern: `<type>/#<issue-number>-<kebab-description>`
+
+### Commit Granularity
+
+1 commit = 1 logical unit. Multiple commits per issue are expected. WIP commits are allowed on feature branches and must be squashed or rebased into clean commits before the PR merge. `main` history must be readable without WIP noise.
+
+### Push Rules
+
+| Action | Rule |
+|---|---|
+| Push to feature branch | Free — no confirmation required |
+| Open PR | Agent opens PR and notifies human in chat |
+| Merge to `main` | Human approval via PR only — agent never merges |
+| Force-push | Never without explicit human instruction |
+
+### PR Lifecycle
+
+```
+1. Create branch: feature/#N-description
+2. Implement: commit (logical units, (#N) suffix)
+3. Push branch
+4. Open PR → notify human in chat
+5. Human: review diff + CI + preview deployment
+6. Human: approve + merge
+7. Close issue with AC verification
+```
+
+### Release Process
+
+See [ADR-0008](decisions/adr/0008-release-strategy.md) for the full release process including branch, tag, and GitHub Release steps.
+
+**Short form:**
+1. Create `release/vX.Y.Z` branch from `main`
+2. Bump version + update CHANGELOG on branch
+3. Tag on release branch: `git tag -a vX.Y.Z`
+4. Create GitHub Release with curated release notes
+5. Merge release branch back to `main`
+
+---
+
+## Known Exceptions
+
+Existing code that pre-dates these conventions is not retroactively fixed. Violations are tracked as GitHub Issues when encountered during active work.
+
+| File | Violation | Issue |
+|---|---|---|
+| `oia-site/src/views/detail.ts:9` | Dynamic `margin-left:${depth * 16}px` — computed indentation, not replaceable by a static class | [#148](https://github.com/ruKurz/oi-architecture/issues/148) |

--- a/prompts/skills/oia-issue-implementieren/references/decisions-README.md
+++ b/prompts/skills/oia-issue-implementieren/references/decisions-README.md
@@ -1,0 +1,107 @@
+# Decision Records
+
+This directory contains two types of decision records for the OIA project:
+
+| Type | Layer | Subject | Location |
+|---|---|---|---|
+| **ADR** — Architecture Decision Record | Arch | Technical and structural choices | `decisions/adr/` |
+| **ODR** — Organizational Decision Record | Org | Operating model, governance, process principles | `decisions/odr/` |
+| **OIA-ODR** — OIA Model Decision Record | Model | OIA layer definitions, element semantics, model governance | `decisions/oia-odr/` |
+
+Both follow the **Decision first** principle (Müller/Dienst). See [`context/odr-concept.md`](../context/odr-concept.md) for the full ODR concept and hierarchy (Gov → Org → Arch).
+
+**Obsolete records** (superseded or deprecated) are stored in [`decisions/_obsolete/`](./_obsolete/README.md). They are never deleted — they remain for historical reference. See `_obsolete/README.md` for the index.
+
+---
+
+## ADR Index
+
+ADR methodology: Ralf D. Müller / Johannes Dienst (fiveandahalfstars.ninja).
+
+| ADR | Title | Status | Type | Date |
+|---|---|---|---|---|
+| [ADR-0001](./adr/0001-language-and-naming-conventions.md) | Language and Naming Conventions | Accepted (language section superseded by ODR-0004) | DEV | 2026-03-11 |
+| [ADR-0002](./adr/0002-biz-dev-separation.md) | BIZ/DEV Separation as Project Rule | Accepted | BOTH | 2026-03-11 |
+| [ADR-0003](./adr/0003-github-issues-as-task-tracker.md) | GitHub Issues as Official Task Tracker | Accepted | DEV | 2026-03-11 |
+| [ADR-0004](./adr/0004-adr-format-mueller-dienst.md) | ADR Format: Müller/Dienst Methodology | Accepted | DEV | 2026-03-11 |
+| [ADR-0005](./adr/0005-conventional-commits-with-content-type.md) | Conventional Commits with Custom Content Type | Accepted | DEV | 2026-03-11 |
+| [ADR-0006](./adr/0006-prompt-helper-enforcement.md) | Prompt-Helper Enforcement via CLAUDE.md | Accepted | DEV | 2026-03-11 |
+| [ADR-0007](./adr/0007-versioning-scheme.md) | Versioning Scheme — Semantic Versioning for OIA | Accepted | BOTH | 2026-03-13 |
+| [ADR-0008](./adr/0008-release-strategy.md) | Release Strategy — GitHub Releases with Manual Trigger | Proposed | DEV | 2026-03-13 |
+| [ADR-0009](./adr/0009-repo-as-source-of-truth-for-contributor-documentation.md) | Repo as Source of Truth — Website as Entry Point | Accepted | DEV | 2026-03-12 |
+| [ADR-0010](./adr/0010-semantic-anchors-as-vocabulary-layer.md) | Semantic Anchors as Shared Vocabulary Layer | Accepted | DEV | 2026-03-12 |
+| ~~[ADR-0011](./_obsolete/0011-english-as-project-language.md)~~ | ~~English as the Sole Project Language~~ | Superseded by ODR-0004 | DEV | 2026-03-13 |
+| [ADR-0012](./adr/0012-introduce-odr-governance-layer.md) | Introduce ODR as Governance Documentation Layer | Accepted | BOTH | 2026-03-14 |
+| [ADR-0013](./adr/0013-issue-reference-in-commit-subject.md) | Issue Reference in Commit Subject Line | Accepted | DEV | 2026-03-28 |
+| [ADR-0014](./adr/0014-feature-branch-release-branch-workflow.md) | Feature-Branch and Release-Branch Development Workflow | Accepted | DEV | 2026-03-28 |
+| [ADR-0015](./adr/0015-sprint-based-development-workflow.md) | Sprint-Based Development Workflow | Accepted | DEV | 2026-03-28 |
+| [ADR-0016](./adr/0016-agile-semantic-anchors.md) | Agile Process Semantic Anchors | Accepted | DEV | 2026-03-28 |
+
+---
+
+## ODR Index
+
+ODRs document organizational decisions at the Org layer of the governance hierarchy. They bind all participants: Users, Agents, and Contributors.
+
+| ODR | Title | Status | Date |
+|---|---|---|---|
+| [ODR-0000](./odr/0000-commit-to-transparent-governance-documentation.md) | Commit to Transparent Governance Documentation | Accepted | 2026-03-14 |
+| [ODR-0001](./odr/0001-oia-ecosystem-type.md) | OIA Ecosystem Type — Community-Driven with Benevolent Dictator | Accepted | 2026-03-14 |
+| [ODR-0002](./odr/0002-adopt-agile-principles.md) | Adopt Agile Software Development Principles | Accepted | 2026-03-14 |
+| [ODR-0003](./odr/0003-adopt-adrs-as-arch-layer-documentation-practice.md) | Adopt ADRs as Arch-Layer Documentation Practice | Accepted | 2026-03-14 |
+| [ODR-0004](./odr/0004-english-as-project-language.md) | English as the Sole Project Language | Accepted | 2026-03-14 |
+
+---
+
+## OIA-ODR Index
+
+OIA-ODRs document model-level decisions — how the OIA model is structured, what its layers mean, and which governance frames apply within the model. They bind Contributors implementing model changes and AI Agents traversing the model.
+
+OIA-ODR numbers are independent of ADR and ODR numbers. The next OIA-ODR number is the current highest in this index + 1.
+
+| OIA-ODR | Title | Status | Date |
+|---|---|---|---|
+| [OIA-ODR-0001](./oia-odr/0001-system-participants-layer.md) | System Participants Layer | Proposed | 2026-03-15 |
+
+---
+
+## ADR Acceptance Rule
+
+**Only a human maintainer may set an ADR status to `Accepted`.**
+
+- AI-assisted tooling must use `Proposed` when creating new ADRs
+- Status changes to `Accepted` require a deliberate manual edit
+- The commit message for an acceptance must reference the ADR number (e.g. `docs(decisions): accept ADR-0001 Refs #43`)
+- An ADR in `Proposed` state is active and followed — `Proposed` means "awaiting human sign-off", not "not yet in use"
+
+---
+
+## Template
+
+```markdown
+# ADR-NNNN: Noun-phrase title
+
+**Decision:** One or two sentences, active voice. What was decided.
+**Status:** Proposed | Accepted | Deprecated | Superseded by ADR-XXXX
+**Date:** YYYY-MM-DD
+**Type:** DEV | BIZ | BOTH
+**Governed by:** ODR-XXXX | — (if no governing ODR applies)
+
+## Context
+
+Facts that influenced the decision. Neutral language — no judgement yet.
+Quality attribute affected (e.g. maintainability, portability, security).
+
+## Consequences
+
+**Easier:** What becomes simpler as a result.
+**Harder:** What becomes more difficult or requires more discipline.
+**Required adjustments:** What else must change to make this decision work.
+
+## Alternatives
+
+| Option | Reason rejected |
+|---|---|
+| Alternative A | Why not chosen |
+| Alternative B | Why not chosen |
+```


### PR DESCRIPTION
## Summary

- Creates `prompts/skills/oia-issue-implementieren/SKILL.md` with YAML frontmatter (discovery layer) and a 5-step workflow body (activation layer)
- Adds `references/` directory with `CONVENTIONS.md` and `decisions-README.md` as on-demand execution-layer context
- Skill covers: pre-flight → branch → implement → commit → PR in correct order
- Does not duplicate CLAUDE.md content — references only

## Test plan

- [ ] Verify `SKILL.md` frontmatter is valid YAML with `name` and `description`
- [ ] Verify `description` is under 1024 characters
- [ ] Verify `references/` contains both files
- [ ] Trigger skill manually: "use skill oia-issue-implementieren for #N"

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)