### PR TITLE
fix(renderer): move spectra to detail view, fix triad item detail views (#173)

### DIFF
--- a/oia-site/src/renderer/render-system-participants.ts
+++ b/oia-site/src/renderer/render-system-participants.ts
@@ -114,9 +114,15 @@ function renderKeyInsight(model: OIAModel, insightId: string): string {
 }
 
 export function renderSystemParticipants(model: OIAModel, layer: Container): string {
-  const [triadId, spectrum1Id, spectrum2Id, insightId] = layer.children
+  const [triadId] = layer.children
   return `<div class="sp-layer">
     ${renderTriad(model, triadId)}
+  </div>`
+}
+
+export function renderSystemParticipantsDetail(model: OIAModel, layer: Container): string {
+  const [, spectrum1Id, spectrum2Id, insightId] = layer.children
+  return `<div class="sp-layer">
     <div class="sp-centric-stmt">${ACTOR_CENTRIC_STMT}</div>
     ${renderSpectrum(model, spectrum1Id)}
     ${renderSpectrum(model, spectrum2Id)}

--- a/oia-site/src/views/detail.ts
+++ b/oia-site/src/views/detail.ts
@@ -1,4 +1,5 @@
-import type { OIAModel, OIAElement } from '../data/types'
+import type { OIAModel, OIAElement, Container } from '../data/types'
+import { renderSystemParticipantsDetail } from '../renderer/render-system-participants'
 
 function renderChildren(model: OIAModel, ids: string[], depth = 0): string {
   if (depth > 3) return ''
@@ -41,16 +42,32 @@ export function renderDetailView(model: OIAModel, id: string): HTMLElement {
   }
 
   const children = el.type === 'container' ? el.children : []
-  const description = el.type === 'container' ? el.description || '' : el.description || ''
+  const description = el.description || ''
+
+  if (el.id === '#L9' && el.type === 'container') {
+    view.innerHTML = `
+      <a class="detail-back" href="#/">← Back to Overview</a>
+      <div class="detail-id">${el.id}</div>
+      <div class="detail-title">${el.label}</div>
+      ${description ? `<div class="detail-desc">${description}</div>` : ''}
+      ${renderSystemParticipantsDetail(model, el as Container)}
+    `
+    return view
+  }
+
+  const childrenHtml =
+    children.length > 0
+      ? `<div class="detail-items">${renderChildren(model, children)}</div>`
+      : description
+        ? ''
+        : '<div class="detail-items"><div class="detail-item detail-item--empty">No sub-elements</div></div>'
 
   view.innerHTML = `
     <a class="detail-back" href="#/">← Back to Overview</a>
     <div class="detail-id">${el.id}</div>
     <div class="detail-title">${el.label}</div>
     ${description ? `<div class="detail-desc">${description}</div>` : ''}
-    <div class="detail-items">
-      ${children.length > 0 ? renderChildren(model, children) : '<div class="detail-item detail-item--empty">No sub-elements</div>'}
-    </div>
+    ${childrenHtml}
   `
   return view
 }

--- a/oia-site/tests/detail.spec.ts
+++ b/oia-site/tests/detail.spec.ts
@@ -35,18 +35,28 @@ describe('renderDetailView', () => {
   })
 
   test('renders children for container element', () => {
-    const el = renderDetailView(model, '#L9')
+    const el = renderDetailView(model, '#L3')
     expect(el.querySelector('.detail-items')).not.toBeNull()
     expect(el.querySelectorAll('.detail-item').length).toBeGreaterThan(0)
   })
 
-  test('shows "No sub-elements" for item without children', () => {
-    // Find any item (not container) in the model
-    const item = (model).elements.find((e) => e.type === 'item')
-    expect(item).toBeDefined()
-    const el = renderDetailView(model, item!.id)
+  test('renders system participants detail view for #L9', () => {
+    const el = renderDetailView(model, '#L9')
+    expect(el.querySelector('.sp-layer')).not.toBeNull()
+    expect(el.querySelector('.sp-spectrum')).not.toBeNull()
+    expect(el.querySelector('.sp-insight')).not.toBeNull()
+  })
+
+  test('shows "No sub-elements" for item without children and no description', () => {
+    const el = renderDetailView(model, '#I2-1')
     expect(el.querySelector('.detail-items')).not.toBeNull()
     expect(el.innerHTML).toContain('No sub-elements')
+  })
+
+  test('does not show "No sub-elements" for triad item with description', () => {
+    const el = renderDetailView(model, '#L9-t-initiator')
+    expect(el.innerHTML).not.toContain('No sub-elements')
+    expect(el.querySelector('.detail-desc')).not.toBeNull()
   })
 
   test('shows not-found message for unknown id', () => {


### PR DESCRIPTION
## Summary

- **Overview (#L9):** renders triad only — spectra, key insight, and actor-centric statement removed
- **Detail view (#L9):** new `renderSystemParticipantsDetail` renders actor-centric statement + Autonomy & Decision Space spectrum + Accountability spectrum + key insight (two-line hierarchy)
- **Triad item detail views:** suppress "No sub-elements" when description exists; description shown via `detail-desc`; items without description still show "No sub-elements"

## AC verification

- [x] Overview shows triad only — no spectra, no key insight box
- [x] Layer detail view shows spectra + key insight with correct order and two-line hierarchy
- [x] Initiator/Actor/Beneficiary detail views show concept description (no "No sub-elements")
- [x] npm test passes — 63/63
- [x] npm run build clean

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)