### PR TITLE
fix(renderer): SP detail UX — clickable elements, horizontal governance flow, actor spectra (#182)

### DIFF
--- a/oia-site/src/renderer/render-system-participants.ts
+++ b/oia-site/src/renderer/render-system-participants.ts
@@ -68,7 +68,7 @@ function renderTriad(model: OIAModel, triadId: string): string {
   return `<div class="sp-triad">${parts.join('')}</div>`
 }
 
-function renderSpectrum(model: OIAModel, spectrumId: string): string {
+export function renderSpectrum(model: OIAModel, spectrumId: string): string {
   const spectrum = getItem(model, spectrumId) as Container | undefined
   if (!spectrum || spectrum.type !== 'container') return ''
 
@@ -107,7 +107,7 @@ function renderSpectrum(model: OIAModel, spectrumId: string): string {
   </div>`
 }
 
-function renderKeyInsight(model: OIAModel, insightId: string): string {
+export function renderKeyInsight(model: OIAModel, insightId: string): string {
   const item = getItem(model, insightId) as ParticipantItem | undefined
   if (!item || item.itemType !== 'keyInsight') return ''
   const full = item.text ?? item.label
@@ -132,6 +132,7 @@ export function renderSystemParticipantsDetail(model: OIAModel, layer: Container
   return `<div class="sp-layer">
     ${renderTriad(model, triadId)}
     <div class="sp-centric-stmt">${ACTOR_CENTRIC_STMT}</div>
+    <div class="sp-spectra-label">Actor types — how they differ</div>
     ${renderSpectrum(model, spectrum1Id)}
     ${renderSpectrum(model, spectrum2Id)}
     ${renderKeyInsight(model, insightId)}

--- a/oia-site/src/router.ts
+++ b/oia-site/src/router.ts
@@ -86,6 +86,7 @@ function renderOverview() {
 function renderDetail(id: string) {
   appContainer.innerHTML = ''
   appContainer.appendChild(renderDetailView(model, id))
+  attachClickHandlers()
 }
 
 function renderPage(viewElement: HTMLElement) {

--- a/oia-site/src/styles/layout.css
+++ b/oia-site/src/styles/layout.css
@@ -1095,6 +1095,28 @@ body::after {
   padding: 0 8px;
 }
 
+/* Attribution label above spectra */
+.sp-spectra-label {
+  font-family: 'Space Mono', monospace;
+  font-size: 9px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-top: 20px;
+  margin-bottom: 4px;
+}
+
+/* Actor detail: spectra context block */
+.detail-actor-context {
+  margin-top: 8px;
+  margin-bottom: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 /* ── Spectrum ── */
 .sp-spectrum {
   display: flex;

--- a/oia-site/src/views/detail.ts
+++ b/oia-site/src/views/detail.ts
@@ -1,5 +1,9 @@
 import type { OIAModel, OIAElement, Container, ParticipantItem } from '../data/types'
-import { renderSystemParticipantsDetail } from '../renderer/render-system-participants'
+import {
+  renderSystemParticipantsDetail,
+  renderSpectrum,
+  renderKeyInsight,
+} from '../renderer/render-system-participants'
 
 function findParent(model: OIAModel, id: string): Container | undefined {
   return model.elements.find(
@@ -54,25 +58,77 @@ function renderRelated(model: OIAModel, id: string): string {
 
 function renderParticipantContext(model: OIAModel, el: ParticipantItem): string {
   if (!el.role) return ''
-  const outgoing = model.connections.filter((c) => c.from === el.id && c.edgeType)
-  const incoming = model.connections.filter((c) => c.to === el.id && c.edgeType)
-  if (outgoing.length === 0 && incoming.length === 0) return ''
-  const rows: string[] = []
-  incoming.forEach((conn) => {
-    const from = model.elements.find((e) => e.id === conn.from)
-    if (!from) return
-    rows.push(
-      `<div class="detail-flow__row"><a class="detail-flow__node" href="#/detail/${encodeURIComponent(from.id)}">${from.label}</a><span class="detail-flow__edge">${conn.edgeType}</span><span class="detail-flow__node detail-flow__node--current">${el.label}</span></div>`,
+  // Collect triad edges: connections between participant items that carry an edgeType
+  const triadEdges = model.connections.filter((c) => {
+    if (!c.edgeType) return false
+    const from = model.elements.find((e) => e.id === c.from)
+    const to = model.elements.find((e) => e.id === c.to)
+    return (
+      from?.type === 'item' &&
+      (from as ParticipantItem).role !== undefined &&
+      to?.type === 'item' &&
+      (to as ParticipantItem).role !== undefined
     )
   })
-  outgoing.forEach((conn) => {
-    const to = model.elements.find((e) => e.id === conn.to)
-    if (!to) return
-    rows.push(
-      `<div class="detail-flow__row"><span class="detail-flow__node detail-flow__node--current">${el.label}</span><span class="detail-flow__edge">${conn.edgeType}</span><a class="detail-flow__node" href="#/detail/${encodeURIComponent(to.id)}">${to.label}</a></div>`,
-    )
+  if (triadEdges.length === 0) return ''
+
+  // Build ordered chain (walk from the node with no incoming edge)
+  const targets = new Set(triadEdges.map((c) => c.to))
+  const sources = new Set(triadEdges.map((c) => c.from))
+  const allNodes = new Set([...sources, ...targets])
+  const firstId = [...allNodes].find((id) => !targets.has(id))
+  if (!firstId) return ''
+
+  const chain: string[] = [firstId]
+  const edgeLabels: string[] = []
+  let current = firstId
+  while (true) {
+    const next = triadEdges.find((c) => c.from === current)
+    if (!next) break
+    edgeLabels.push(next.edgeType!)
+    chain.push(next.to)
+    current = next.to
+  }
+
+  // Render single horizontal row
+  const parts: string[] = []
+  chain.forEach((nodeId, i) => {
+    if (i > 0) {
+      parts.push(`<span class="detail-flow__edge">${edgeLabels[i - 1]}</span>`)
+    }
+    const node = model.elements.find((e) => e.id === nodeId)
+    if (!node) return
+    if (nodeId === el.id) {
+      parts.push(`<span class="detail-flow__node detail-flow__node--current">${node.label}</span>`)
+    } else {
+      parts.push(
+        `<a class="detail-flow__node" href="#/detail/${encodeURIComponent(nodeId)}">${node.label}</a>`,
+      )
+    }
   })
-  return `<div class="detail-flow"><div class="detail-flow__label">Governance flow</div>${rows.join('')}</div>`
+
+  return `<div class="detail-flow"><div class="detail-flow__label">Governance flow</div><div class="detail-flow__row">${parts.join('')}</div></div>`
+}
+
+function renderActorSpectraContext(model: OIAModel, el: ParticipantItem): string {
+  if (el.role !== 'actor') return ''
+  // Walk up to the grandparent layer (el → triad container → layer)
+  const triad = model.elements.find(
+    (e): e is Container => e.type === 'container' && e.children.includes(el.id),
+  )
+  if (!triad) return ''
+  const layer = model.elements.find(
+    (e): e is Container => e.type === 'container' && e.children.includes(triad.id),
+  )
+  if (!layer) return ''
+  // layer.children = [triadId, spectrum1Id, spectrum2Id, insightId]
+  const [, spectrum1Id, spectrum2Id, insightId] = layer.children
+  if (!spectrum1Id) return ''
+  return `<div class="detail-actor-context">
+    ${renderSpectrum(model, spectrum1Id)}
+    ${renderSpectrum(model, spectrum2Id)}
+    ${insightId ? renderKeyInsight(model, insightId) : ''}
+  </div>`
 }
 
 function renderChildren(model: OIAModel, ids: string[], depth = 0): string {
@@ -132,10 +188,10 @@ export function renderDetailView(model: OIAModel, id: string): HTMLElement {
     return view
   }
 
-  const participantContext =
-    el.type === 'item' && el.itemType === 'participant'
-      ? renderParticipantContext(model, el as ParticipantItem)
-      : ''
+  const participantEl =
+    el.type === 'item' && el.itemType === 'participant' ? (el as ParticipantItem) : null
+  const participantContext = participantEl ? renderParticipantContext(model, participantEl) : ''
+  const actorSpectra = participantEl ? renderActorSpectraContext(model, participantEl) : ''
 
   const childrenHtml =
     children.length > 0
@@ -150,6 +206,7 @@ export function renderDetailView(model: OIAModel, id: string): HTMLElement {
     <div class="detail-title">${el.label}</div>
     ${description ? `<div class="detail-desc">${description}</div>` : ''}
     ${participantContext}
+    ${actorSpectra}
     ${childrenHtml}
     ${related}
   `


### PR DESCRIPTION
## Summary

- **Clickable elements**: `router.ts` now calls `attachClickHandlers()` after `renderDetail()` — triad and spectrum boxes in the layer detail view are navigable
- **Governance flow**: `renderParticipantContext` rewritten as a single horizontal chain (Initiator → Actor → Beneficiary) with edge type labels between nodes; active participant is highlighted, others link to their own detail pages
- **Actor spectra context**: `#L9-t-actor` detail page now renders both Autonomy and Accountability spectra + Key Insight below the description (via new `renderActorSpectraContext`)
- **Attribution label**: "Actor types — how they differ" label added above the spectra section in the layer detail view

## Test plan
- [ ] All 63 tests pass (`npx vitest run`)
- [ ] Navigate to `#/detail/%23L9` → click a triad box → navigates to participant detail
- [ ] Participant detail shows single-row governance flow with two edge-label arrows
- [ ] `#L9-t-actor` detail shows both spectra and key insight below description
- [ ] `#L9` layer detail shows "Actor types — how they differ" label before spectra

🤖 Generated with [Claude Code](https://claude.com/claude-code)