### PR TITLE
fix(renderer): accountability spectrum items navigate to autonomy counterparts (#196)

### DIFF
--- a/oia-site/src/renderer/render-system-participants.ts
+++ b/oia-site/src/renderer/render-system-participants.ts
@@ -80,7 +80,19 @@ export function renderSpectrum(model: OIAModel, spectrumId: string): string {
       if (!item) return ''
       const colorClass = COLOR_CLASS[item.color ?? ''] ?? ''
       const convergingClass = item.converging ? ' sp-spectrum__entity--converging' : ''
-      return `<div class="sp-spectrum__entity ${colorClass}${convergingClass}" data-id="${item.id}">
+      // Accountability items navigate to their Autonomy counterpart so both spectra
+      // land on the same Actor type detail page (which carries full content).
+      const clickId =
+        item.spectrumAxis === 'accountability'
+          ? (model.elements.find(
+              (e): e is ParticipantItem =>
+                e.type === 'item' &&
+                e.itemType === 'participant' &&
+                (e as ParticipantItem).spectrumAxis === 'autonomy' &&
+                (e as ParticipantItem).label === item.label,
+            )?.id ?? item.id)
+          : item.id
+      return `<div class="sp-spectrum__entity ${colorClass}${convergingClass}" data-id="${clickId}">
         <span class="sp-spectrum__entity-label">${item.label}</span>
         ${(item.caption ?? item.description) ? `<span class="sp-spectrum__entity-desc">${item.caption ?? item.description}</span>` : ''}
       </div>`


### PR DESCRIPTION
## Summary

- Accountability spectrum items (`#L9-sc-*`) now use `data-id` of their Autonomy counterpart (`#L9-sa-*`), so clicking Human/Agent/System in the Accountability spectrum lands on the same Actor type detail page as the Autonomy spectrum

## What changed

`oia-site/src/renderer/render-system-participants.ts` — `renderSpectrum`:
- For items with `spectrumAxis === 'accountability'`, resolve the matching autonomy item (same label, `spectrumAxis === 'autonomy'`) and use that ID as `data-id`
- Falls back to own ID if no counterpart found

## Test plan

- [ ] Navigate to Actor or Initiator/Beneficiary detail page — both spectra visible
- [ ] Click Human/Agent/System in Accountability spectrum → lands on same page as clicking in Autonomy spectrum
- [ ] All 63 tests green ✅

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)