### PR TITLE
fix(renderer): inject Actor breadcrumb level on participant detail pages (#197)

### DIFF
--- a/oia-site/src/views/detail.ts
+++ b/oia-site/src/views/detail.ts
@@ -34,12 +34,23 @@ function renderBreadcrumb(model: OIAModel, id: string): string {
     (a) => !BREADCRUMB_SKIP_TYPES.has(a.containerType) && a.navigationVisible !== false,
   )
   const el = model.elements.find((e) => e.id === id)
+  // Inject explicit parent element between container ancestors and current item.
+  // Used by Actor type items (Human/Agent/System) to show "… › Actor › Human".
+  const explicitParentId = el?.type === 'item' ? (el as ContentItem).parent : undefined
+  const explicitParent = explicitParentId
+    ? model.elements.find((e) => e.id === explicitParentId)
+    : undefined
   const parts: string[] = [`<a class="detail-breadcrumb__item" href="#/">OIA</a>`]
   ancestors.forEach((anc) => {
     parts.push(
       `<span class="detail-breadcrumb__sep">›</span><a class="detail-breadcrumb__item" href="#/detail/${encodeURIComponent(anc.id)}">${anc.label}</a>`,
     )
   })
+  if (explicitParent) {
+    parts.push(
+      `<span class="detail-breadcrumb__sep">›</span><a class="detail-breadcrumb__item" href="#/detail/${encodeURIComponent(explicitParent.id)}">${explicitParent.label}</a>`,
+    )
+  }
   if (el) {
     parts.push(
       `<span class="detail-breadcrumb__sep">›</span><span class="detail-breadcrumb__item detail-breadcrumb__item--current">${el.label}</span>`,


### PR DESCRIPTION
## Summary

- Breadcrumb on Actor type detail pages now reads `System Participants › Actor › Human` instead of `System Participants › Human`
- Uses the `parent` field already set on model items (`"parent": "#L9-t-actor"`) — the renderer just wasn't consuming it

## What changed

`oia-site/src/views/detail.ts` — `renderBreadcrumb`:
- After building container ancestors, check if the element has an explicit `parent` field (`ContentItem.parent`)
- If present, inject that element as an intermediate breadcrumb link before the current item

## Test plan

- [ ] Navigate to `/detail/#L9-sa-human` → breadcrumb reads `OIA › System Participants › Actor › Human`
- [ ] Navigate to `/detail/#L9-sa-agent` → breadcrumb reads `OIA › System Participants › Actor › Agent`
- [ ] Navigate to `/detail/#L9-sa-system` → breadcrumb reads `OIA › System Participants › Actor › System`
- [ ] "Actor" breadcrumb segment is a clickable link back to the Actor triad detail page
- [ ] All 63 tests green ✅

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)