### PR TITLE
docs(process): sprint retro improvements from 2026-03-15-00 (#170)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ See CONVENTIONS.md §Git Workflow and [ADR-0014](decisions/adr/0014-feature-bran
 
 **Branch check before commit:** Before staging and committing, verify the current branch with `git branch --show-current` — especially when switching between feature branches mid-session. Never commit to the wrong branch.
 
-**Agent push autonomy:** Push to a feature branch at any time — no chat confirmation required. Notify the human in chat when opening a PR.
+**Agent push autonomy:** Push to `feature/*`, `fix/*`, and `chore/*` branches at any time — no chat confirmation required. Notify the human in chat when opening a PR.
 
 **Never merge to main:** Open the PR, summarize the changes in chat, and wait for human approval. The human merges.
 

--- a/prompts/development/sprint-refinement.md
+++ b/prompts/development/sprint-refinement.md
@@ -74,6 +74,24 @@ If the issue is a cross-cutting concept: check the integration point checklist (
 
 ---
 
+#### R-4.1 — Renderer / visual scope (if applicable)
+
+Skip if the issue has no renderer or visual output.
+
+**Visual spec requirement:** Before this issue can be sprint-ready, one of the following must exist:
+- An annotated screenshot or annotated HTML prototype attached to the issue, OR
+- An explicit CSS spec block (property + value + selector), OR
+- A link to a rendered preview that defines the expected visual state
+
+If no artifact exists: draft a minimal spec inline in the issue body, or flag the issue as not sprint-ready.
+
+**Model + renderer design decision:** If the issue touches both model types (`types.ts`, `oia-model.json`) and renderer logic:
+- Field names (new properties on model items) must be decided now — not mid-implementation
+- Visual vocabulary (class names, element structure) must be agreed before coding begins
+- Document these as a `## Design notes` block in the issue body before marking sprint-ready
+
+---
+
 #### R-5 — Size estimate
 
 Confirm or revise the size:
@@ -128,6 +146,8 @@ If sub-issues were approved: create them.
 | Issue depends on an unresolved decision | Flag as `blocked by #N` in AC — do not refine further |
 | Issue is XL (multi-day) | Always recommend splitting — do not mark as sprint-ready |
 | AC item cannot be verified pre-deploy | Mark `(post-deploy)` — still valid, does not block close |
+| Renderer / visual issue — no artifact | Block sprint-ready — create or draft spec artifact first |
+| Model + renderer issue — no design notes | Block sprint-ready — document field names and visual vocabulary in issue body first |
 
 ---
 
@@ -139,6 +159,8 @@ If sub-issues were approved: create them.
 - [ ] Size confirmed
 - [ ] Issue body updated in GitHub
 - [ ] Sub-issues created if needed and approved
+- [ ] Renderer / visual issues: reference artifact confirmed or noted in issue body
+- [ ] Model + renderer issues: design decisions documented in issue body (`## Design notes`)
 
 ---
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: push autonomy now explicitly includes `feature/*`, `fix/*`, and `chore/*` (was "a feature branch")
- **sprint-refinement.md**: new step R-4.1 — renderer/visual scope check and model+renderer design decision requirement

## Test plan

- [ ] CLAUDE.md: "Agent push autonomy" line names all three branch prefixes
- [ ] sprint-refinement.md: R-4.1 step present between R-4 and R-5
- [ ] sprint-refinement.md: two new decision rules in table
- [ ] sprint-refinement.md: two new AC items

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)