### PR TITLE
fix(renderer): add missing ContentItem import in detail.ts (#197)

### DIFF
--- a/oia-site/src/views/detail.ts
+++ b/oia-site/src/views/detail.ts
@@ -1,4 +1,4 @@
-import type { OIAModel, OIAElement, Container, ParticipantItem } from '../data/types'
+import type { OIAModel, OIAElement, Container, ContentItem, ParticipantItem } from '../data/types'
 import {
   renderSystemParticipantsDetail,
   renderSpectrum,


### PR DESCRIPTION
## Summary

Hotfix for the broken build after #195/#197 merge. The breadcrumb fix uses `el as ContentItem` but `ContentItem` was missing from the import line.

**Error:** `src/views/detail.ts(39,57): error TS2304: Cannot find name 'ContentItem'`

Build verified locally ✅

Refs #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)