### PR TITLE
fix(infra): resolve flatted prototype pollution vulnerability (#219)

### DIFF
--- a/oia-site/package-lock.json
+++ b/oia-site/package-lock.json
@@ -2613,9 +2613,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary

- Runs `npm audit fix` to update `flatted` to a safe version in the lockfile
- Fixes CI Security audit failures on Dependabot PRs #211 and #213
- No production dependencies changed

## Test plan

- [ ] `npm audit --audit-level=moderate` → 0 vulnerabilities ✓ (verified locally)
- [ ] CI Security audit passes

## Note on PR #210

@vitest/ui 4.1.0 brings in its own vulnerable `flatted` at the package level — not fixable via lockfile update. PR #210 should be closed until vitest patches upstream.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)