### PR TITLE
fix(infra): pin vitest and @vitest/ui to 4.0.18 to avoid flatted vulnerability (#219)

### DIFF
--- a/oia-site/package-lock.json
+++ b/oia-site/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@vitest/ui": "^4.0.18",
+        "@vitest/ui": "4.0.18",
         "eslint": "^10.0.3",
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
@@ -19,7 +19,7 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1",
-        "vitest": "^4.0.18"
+        "vitest": "4.0.18"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/oia-site/package.json
+++ b/oia-site/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@vitest/ui": "^4.0.18",
+    "@vitest/ui": "4.0.18",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
@@ -38,6 +38,6 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1",
-    "vitest": "^4.0.18"
+    "vitest": "4.0.18"
   }
 }


### PR DESCRIPTION
## Summary

- Pins `vitest` and `@vitest/ui` to exact version `4.0.18` in `package.json` (removes `^`)
- Runs `npm install` to regenerate lockfile with safe `flatted` transitive dependency
- `^4.0.18` was resolving to `4.1.x` which ships a vulnerable `flatted <=3.4.1`

## Test plan

- [ ] `npm audit --audit-level=moderate` → 0 vulnerabilities ✓
- [ ] 63/63 tests pass ✓
- [ ] CI Security audit passes

## Effect on Dependabot PRs

- #211 (typescript-eslint) and #213 (lint-staged) will pass CI after Dependabot rebases onto this fix
- #210 (@vitest/ui 4.1.0) should be closed — that PR is the source of the vulnerability

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)