### PR TITLE
chore(process): sprint retro improvements — sprint-scope gate and research issue (#206)

### DIFF
--- a/prompts/development/create-issue.md
+++ b/prompts/development/create-issue.md
@@ -103,6 +103,18 @@ gh issue create \
 
 Output the created issue URL.
 
+### Step 6 — Sprint-scope gate
+
+After the issue is created, ask:
+
+> "Is a sprint currently active? Should this issue be added to the sprint?"
+
+- **No active sprint** → done.
+- **Yes, sprint extension** → immediately route to `prompts/development/sprint-scope-change.md`. Do not add the issue to the sprint file directly.
+- **Uncertain** → ask the user before proceeding.
+
+This step closes the feedback loop between issue creation and sprint tracking.
+
 ---
 
 ## Decision rules


### PR DESCRIPTION
## Summary

Implements the two actionable measures from sprint retro 2026-03-15-00 (#206).

**Measure 1 — Sprint-scope gate in `create-issue.md`**
Adds Step 6: after issue creation, ask whether a sprint is active and route to `sprint-scope-change.md` if yes. Closes the feedback loop that caused the 6→22 issue scope gap going untracked during sprint 2026-03-15.

**Measure 2 — ADR-0017 research issue**
Created #231: dedicated capability research session on Claude Code's slash-command trigger model before any Skills implementation. ADR-0017 remains `Proposed` until findings are documented.

**Measure 3 — `tsc --noEmit` CI step**
Already present in `.github/workflows/pr-check.yml` as the `Typecheck` step — AC satisfied without change.

## Acceptance criteria status

- [x] `create-issue.md` asks about sprint extension and routes to `sprint-scope-change.md` if yes
- [x] prompt-helper.md compliance pre-flight passed (all 4 required sections present)
- [x] ADR-0017 research issue created (#231); ADR-0017 remains Proposed
- [x] `tsc --noEmit` step present in `pr-check.yml` (already satisfied)

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)