### PR TITLE
chore(process): add scope rule — no private project names in public issues (#253)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,11 @@ Follow CONVENTIONS.md §2.3. Every commit subject ends with `(#N)`. Every commit
 Official tasks: GitHub Issues at https://github.com/ruKurz/oi-architecture/issues
 `context/todo.md` is a session parking lot only — not the primary tracker.
 
+**No private project names in public artifacts.**
+Before creating or editing a GitHub Issue, PR, or commit message that references an external project, system, or codebase: verify the referenced project is publicly known (open source, published, or explicitly approved by the maintainer).
+Never include names, paths, or details of private, proprietary, or non-public projects in any public repository artifact.
+When a private project serves as a test or reference object: describe it generically ("a reference project", "an internal knowledge system") — never by name.
+
 ## Version Identity
 
 **Current OIA version: `0.3.0`**

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -108,6 +108,18 @@ Categories: `model` · `renderer` · `prompt` · `architecture` · `infra` · `u
 
 See [ADR-0003](decisions/adr/0003-github-issues-as-task-tracker.md) for rationale.
 
+### No Private Names in Public Artifacts
+
+**Before creating or editing any public artifact (GitHub Issue, PR, commit message):**
+
+- Verify that any referenced external project, system, or codebase is publicly known (open source, published, or explicitly approved by the maintainer for public mention)
+- Never include names, paths, or details of private, proprietary, or non-public projects
+- When a private project serves as a test or reference object: describe it generically — "a reference project", "an internal knowledge system" — not by name
+
+Rationale: This repository is public. Private project names in Issues, PRs, or commits are permanently visible and cannot be reliably removed from git history or GitHub's search index.
+
+See [#253](https://github.com/ruKurz/oi-architecture/issues/253) for the incident that prompted this rule.
+
 ### No-Duplicate Rule
 
 **Every workflow that creates GitHub Issues must run the duplicate check first — without exception.**


### PR DESCRIPTION
## Summary

- Adds binding rule to `CLAUDE.md` (agent contract, effective immediately)
- Adds rule to `CONVENTIONS.md §2.4` (developer contract, before the No-Duplicate Rule)
- Rule: external projects referenced in public artifacts must be publicly known; private projects described generically
- Triggered by incident in sprint 2026-03-29 (#243 contained a private project name)

## Test plan

- [x] Rule added to `CLAUDE.md`
- [x] Rule added to `CONVENTIONS.md §2.4`
- [x] Issue #243 already neutralized (confirmed in AC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)